### PR TITLE
Disable elk logging when running locally, add function for optional config.

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -26,8 +26,13 @@ class Config(configuration: Configuration) extends AwsInstanceTags {
   }
   val config = ConfigurationMagic(appName, configMagicMode).load
 
+  def getOptionalProperty[T](path: String, getVal: String => T) = {
+    if (config.hasPath(path)) Some(getVal(path))
+    else None
+  }
+
   val elkKinesisStream = config.getString("elk.kinesis.stream")
-  val elkLoggingEnabled = true
+  val elkLoggingEnabled = getOptionalProperty("elk.logging.enabled", config.getBoolean).getOrElse(true)
 
 }
 


### PR DESCRIPTION
This allows elk logging to be disabled via a config property (enabled by default). After this PR is merged everyone will need to re-run ./fetch-config.sh to get the property to disable logging. 

This PR also adds a function to fetch config values which might not be defined. Sadly, the typesafe config library doesn't have something to do this out the box.