### PR TITLE
Add graphql loader to webpack

### DIFF
--- a/conf/webpack.conf.js
+++ b/conf/webpack.conf.js
@@ -31,6 +31,11 @@ module.exports = {
             {
                 test: /\.(ttf|eot|svg|gif|png)(\?v=[0-9].[0-9].[0-9])?$/,
                 loader: "file-loader?name=[name].[ext]"
+            },
+            {
+                test: /\.(graphql|gql)$/,
+                exclude: /node_modules/,
+                loader: 'graphql-tag/loader'
             }
         ]
     },


### PR DESCRIPTION
graphql-tag comes with a webpack loader, meaning we can separate our queries into .graphql files and include them where needed:

https://github.com/apollostack/graphql-tag