### PR TITLE
Remove rootReducer

### DIFF
--- a/public/js/reducers/rootReducer.js
+++ b/public/js/reducers/rootReducer.js
@@ -1,8 +1,0 @@
-import { combineReducers } from 'redux';
-import config from './configReducer';
-import error from './errorReducer';
-
-export default combineReducers({
-  config,
-  error
-});

--- a/public/js/util/configureStore.js
+++ b/public/js/util/configureStore.js
@@ -1,7 +1,13 @@
-import { compose, createStore, applyMiddleware } from 'redux';
+import { compose, createStore, applyMiddleware, combineReducers } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 
-import rootReducer from '../reducers/rootReducer';
+import config from '../reducers/configReducer';
+import error from '../reducers/errorReducer';
+
+const rootReducer = combineReducers({
+  config,
+  error
+});
 
 const createStoreWithMiddleware = compose(
     applyMiddleware(


### PR DESCRIPTION
As `rootReducer.js` isn't a reducer, and more of a config step, I moved this functionality to the `configureStore.js` file.

If it gets out of hand, we should create another util to handle them all.