### PR TITLE
Add GET, POST endpoints for atoms

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -13,12 +13,10 @@ class AppComponents(context: Context)
 
   lazy val router = new Routes(httpErrorHandler, appController, healthcheckController, loginController, assets)
   lazy val assets = new controllers.Assets(httpErrorHandler)
-  lazy val appController = new controllers.App(wsClient, previewAtomDataStore)
+  lazy val appController = new controllers.App(wsClient)
   lazy val loginController = new controllers.Login(wsClient)
   lazy val healthcheckController = new controllers.Healthcheck()
 
-  lazy val previewAtomDataStore = AtomDataStores.previewStore
-  lazy val publishedAtomDataStore = AtomDataStores.publishedStore
 }
 
 

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,10 +1,10 @@
-import data.AtomDataStores
 import config.LogConfig
 import play.api._
 import play.api.ApplicationLoader.Context
 import play.api.libs.ws.ahc.AhcWSComponents
 import router.Routes
 import config._
+import db.AtomDataStores
 
 class AppComponents(context: Context)
   extends BuiltInComponentsFromContext(context) with AhcWSComponents {

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -30,7 +30,7 @@ class App(val wsClient: WSClient) extends Controller with PanDomainAuthActions {
       for {
         atomType <- validateAtomType(atomType)
         ds <- AtomDataStores.getDataStore(atomType, getVersion(version))
-        atom <- AtomWorkshopDB.getAtom(ds, atomType, id)
+        atom <- ds.getAtom(AtomWorkshopDB.buildKey(atomType, id))
       } yield atom
     }
   }

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -6,8 +6,8 @@ import play.api.Logger
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import cats.syntax.either._
-import com.gu.fezziwig.CirceScroogeMacros._
 import db.{AtomDataStores, AtomWorkshopDB}
+import com.gu.fezziwig.CirceScroogeMacros._
 import io.circe._
 import io.circe.generic.auto._
 import io.circe.syntax._
@@ -30,7 +30,7 @@ class App(val wsClient: WSClient) extends Controller with PanDomainAuthActions {
       for {
         atomType <- validateAtomType(atomType)
         ds <- AtomDataStores.getDataStore(atomType, getVersion(version))
-        atom <- ds.getAtom(AtomWorkshopDB.buildKey(atomType, id))
+        atom <- AtomWorkshopDB.getAtom(ds, atomType, id)
       } yield atom
     }
   }

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -1,20 +1,17 @@
 package controllers
 
-import com.gu.atom.data.{DynamoCompositeKey, DynamoDataStore, PreviewDataStore}
-import com.gu.contentatom.thrift.{Atom, AtomData, AtomType, ContentChangeDetails}
-import com.gu.contentatom.thrift.AtomData.Media
 import config.Config
 import models._
 import play.api.Logger
 import play.api.libs.ws.WSClient
-import play.api.libs.json.Json
 import play.api.mvc._
-import com.gu.contentatom.thrift.atom.media._
 import cats.syntax.either._
-import data.AtomDataStores
-import cats.syntax.either._
-import com.gu.contentatom.thrift.atom.cta.CTAAtom
-import com.gu.contentatom.thrift.atom.explainer.{DisplayType, ExplainerAtom}
+import com.gu.fezziwig.CirceScroogeMacros._
+import db.{AtomDataStores, AtomWorkshopDB}
+import io.circe._
+import io.circe.generic.auto._
+import io.circe.syntax._
+import util.HelperFunctions._
 
 class App(val wsClient: WSClient) extends Controller with PanDomainAuthActions {
 
@@ -25,62 +22,27 @@ class App(val wsClient: WSClient) extends Controller with PanDomainAuthActions {
       username = req.user.email
     )
 
-    Ok(views.html.index("Atomyatomatom", Json.toJson(clientConfig).toString()))
+    Ok(views.html.index("AtomMcAtomFace", clientConfig.asJson.noSpaces))
   }
-
-  def getVersion(version: String): Version = version match {
-    case "preview" => Preview
-    case "live" => Live
-  }
-
-  def validateAtomType(atomType: String): Either[AtomAPIError, AtomType] = {
-    val t = AtomType.valueOf(atomType)
-    Either.cond(t.isDefined, t.get, InvalidAtomTypeError)
-  }
-
-  def buildKey(atomType: AtomType, id: String) = DynamoCompositeKey(atomType.name, Some(id))
 
   def getAtom(atomType: String, id: String, version: String) = AuthAction {
-    val atomRes = for {
-      atomType <- validateAtomType(atomType)
-      ds <- AtomDataStores.getDataStore(atomType, getVersion(version))
-    } yield {
-      ds.getAtom(buildKey(atomType, id)).fold(err => {
-        Logger.error(s"Failed to get atom with type ${atomType.name} and id $id. Error message: ${err.msg}")
-        NotFound(err.msg)
-      }, atom => Ok(atom.toString()))
+    APIResponse {
+      for {
+        atomType <- validateAtomType(atomType)
+        ds <- AtomDataStores.getDataStore(atomType, getVersion(version))
+        atom <- AtomWorkshopDB.getAtom(ds, atomType, id)
+      } yield atom
     }
-    atomRes.fold(err => BadRequest(err.msg), atom => atom)
-
   }
 
   def createAtom(atomType: String) = AuthAction {
-
-    Logger.info(s"Attempting to create atom with type $atomType")
-
-    def buildDefaultAtom(atomType: AtomType) = {
-      val defaultAtoms: Map[AtomType, AtomData] = Map(
-        AtomType.Explainer -> AtomData.Explainer(ExplainerAtom("", "", DisplayType.Flat)),
-        AtomType.Cta -> AtomData.Cta(CTAAtom(""))
-      )
-
-      Atom(id = java.util.UUID.randomUUID.toString,
-        atomType = atomType,
-        defaultHtml = s"""<div class="atom-${atomType.name}"></div>""",
-        data = defaultAtoms(atomType),
-        contentChangeDetails = ContentChangeDetails(revision = 0L))
+    APIResponse{
+      for {
+        atomType <- validateAtomType(atomType)
+        ds <- AtomDataStores.getDataStore(atomType, Preview)
+        result <- AtomWorkshopDB.createAtom(ds, atomType)
+      } yield AtomWorkshopAPIResponse("Atom creation successful")
     }
-
-    val res = for {
-      atomType <- validateAtomType(atomType)
-      ds <- AtomDataStores.getDataStore(atomType, Preview)
-    } yield {
-      val defaultAtom = buildDefaultAtom(atomType)
-      Logger.info(s"Attempting to create atom of type ${atomType.name} with id ${defaultAtom.id}")
-      ds.createAtom(defaultAtom)
-    }
-
-    res.fold(err => BadRequest(err.msg), r => r.fold(err => InternalServerError(err.msg), a => Ok("Atom succesfully created.")))
   }
 
 }

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -1,31 +1,86 @@
 package controllers
 
-import com.gu.atom.data.{DynamoCompositeKey, PreviewDataStore}
-import com.gu.contentatom.thrift.AtomData
+import com.gu.atom.data.{DynamoCompositeKey, DynamoDataStore, PreviewDataStore}
+import com.gu.contentatom.thrift.{Atom, AtomData, AtomType, ContentChangeDetails}
 import com.gu.contentatom.thrift.AtomData.Media
 import config.Config
-import model.ClientConfig
+import models._
 import play.api.Logger
 import play.api.libs.ws.WSClient
 import play.api.libs.json.Json
 import play.api.mvc._
 import com.gu.contentatom.thrift.atom.media._
 import cats.syntax.either._
+import data.AtomDataStores
+import cats.syntax.either._
+import com.gu.contentatom.thrift.atom.cta.CTAAtom
+import com.gu.contentatom.thrift.atom.explainer.{DisplayType, ExplainerAtom}
 
-class App(val wsClient: WSClient, previewDataStore: PreviewDataStore) extends Controller with PanDomainAuthActions {
+class App(val wsClient: WSClient) extends Controller with PanDomainAuthActions {
 
   def index = AuthAction { req =>
     Logger.info(s"I am the ${Config.appName}")
-
-    val someAtom = previewDataStore.getAtom(DynamoCompositeKey("Media", Some("8ba4c6c8-0815-45d9-9e87-0a6c20954094"))).fold(
-      err => err.msg,
-      atom => atom.data.asInstanceOf[AtomData.Media].media.title
-    )
 
     val clientConfig = ClientConfig(
       username = req.user.email
     )
 
-    Ok(views.html.index(someAtom, Json.toJson(clientConfig).toString()))
+    Ok(views.html.index("Atomyatomatom", Json.toJson(clientConfig).toString()))
   }
+
+  def getVersion(version: String): Version = version match {
+    case "preview" => Preview
+    case "live" => Live
+  }
+
+  def validateAtomType(atomType: String): Either[AtomAPIError, AtomType] = {
+    val t = AtomType.valueOf(atomType)
+    Either.cond(t.isDefined, t.get, InvalidAtomTypeError)
+  }
+
+  def buildKey(atomType: AtomType, id: String) = DynamoCompositeKey(atomType.name, Some(id))
+
+  def getAtom(atomType: String, id: String, version: String) = AuthAction {
+    val atomRes = for {
+      atomType <- validateAtomType(atomType)
+      ds <- AtomDataStores.getDataStore(atomType, getVersion(version))
+    } yield {
+      ds.getAtom(buildKey(atomType, id)).fold(err => {
+        Logger.error(s"Failed to get atom with type ${atomType.name} and id $id. Error message: ${err.msg}")
+        NotFound(err.msg)
+      }, atom => Ok(atom.toString()))
+    }
+    atomRes.fold(err => BadRequest(err.msg), atom => atom)
+
+  }
+
+  def createAtom(atomType: String) = AuthAction {
+
+    Logger.info(s"Attempting to create atom with type $atomType")
+
+    def buildDefaultAtom(atomType: AtomType) = {
+      val defaultAtoms: Map[AtomType, AtomData] = Map(
+        AtomType.Explainer -> AtomData.Explainer(ExplainerAtom("", "", DisplayType.Flat)),
+        AtomType.Cta -> AtomData.Cta(CTAAtom(""))
+      )
+
+      Atom(id = java.util.UUID.randomUUID.toString,
+        atomType = atomType,
+        defaultHtml = s"""<div class="atom-${atomType.name}"></div>""",
+        data = defaultAtoms(atomType),
+        contentChangeDetails = ContentChangeDetails(revision = 0L))
+    }
+
+    val res = for {
+      atomType <- validateAtomType(atomType)
+      ds <- AtomDataStores.getDataStore(atomType, Preview)
+    } yield {
+      val defaultAtom = buildDefaultAtom(atomType)
+      Logger.info(s"Attempting to create atom of type ${atomType.name} with id ${defaultAtom.id}")
+      ds.createAtom(defaultAtom)
+    }
+
+    res.fold(err => BadRequest(err.msg), r => r.fold(err => InternalServerError(err.msg), a => Ok("Atom succesfully created.")))
+  }
+
 }

--- a/app/data/AtomDataStores.scala
+++ b/app/data/AtomDataStores.scala
@@ -1,21 +1,60 @@
 package data
 
-import com.gu.atom.data.{PublishedDynamoDataStore, PreviewDynamoDataStore}
+import com.gu.atom.data._
 import com.gu.contentatom.thrift._
 import com.gu.contentatom.thrift.atom.media.MediaAtom
 import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
 import com.gu.scanamo.DynamoFormat
 import DynamoFormat._
 import cats.syntax.either._
+import com.gu.contentatom.thrift.atom.explainer.ExplainerAtom
+import com.gu.contentatom.thrift.atom.cta.CTAAtom
 import config.Config
+import models.{Live, Preview, UnsupportedAtomTypeError, Version}
+
+import scala.reflect.ClassTag
+
 
 object AtomDataStores {
-  val previewStore = new PreviewDynamoDataStore[MediaAtom](Config.dynamoDB, Config.previewDynamoTableName) {
+
+  val explainerDynamoFormats = new AtomDynamoFormats[ExplainerAtom] {
+    def fromAtomData: PartialFunction[AtomData, ExplainerAtom] = { case AtomData.Explainer(data) => data }
+    def toAtomData(data: ExplainerAtom): AtomData = AtomData.Explainer(data)
+  }
+
+  val ctaDynamoFormats = new AtomDynamoFormats[CTAAtom] {
+    def fromAtomData: PartialFunction[AtomData, CTAAtom] = { case AtomData.Cta(data) => data }
+    def toAtomData(data: CTAAtom): AtomData = AtomData.Cta(data)
+  }
+
+  val mediaDynamoFormats = new AtomDynamoFormats[MediaAtom] {
     def fromAtomData: PartialFunction[AtomData, MediaAtom] = { case AtomData.Media(data) => data }
     def toAtomData(data: MediaAtom): AtomData = AtomData.Media(data)
   }
-  val publishedStore = new PublishedDynamoDataStore[MediaAtom](Config.dynamoDB, Config.publishedDynamoTableName) {
-    def fromAtomData: PartialFunction[AtomData, MediaAtom] = { case AtomData.Media(data) => data }
-    def toAtomData(data: MediaAtom): AtomData = AtomData.Media(data)
+
+  def getDataStores[T: ClassTag: DynamoFormat](dynamoFormats: AtomDynamoFormats[T]): Map[Version, DynamoDataStore[T]] = {
+    Map(Preview -> new PreviewDynamoDataStore[T](Config.dynamoDB, Config.previewDynamoTableName) {
+      def fromAtomData = dynamoFormats.fromAtomData
+      def toAtomData(data: T) = dynamoFormats.toAtomData(data)
+    },
+      Live -> new PublishedDynamoDataStore[T](Config.dynamoDB, Config.publishedDynamoTableName) {
+        def fromAtomData = dynamoFormats.fromAtomData
+        def toAtomData(data: T) = dynamoFormats.toAtomData(data)
+      })
+  }
+
+  val dataStores: Map[AtomType, Map[Version, DynamoDataStore[_ >: ExplainerAtom with CTAAtom with MediaAtom]]] = Map(
+    AtomType.Explainer -> getDataStores[ExplainerAtom](explainerDynamoFormats),
+    AtomType.Cta -> getDataStores[CTAAtom](ctaDynamoFormats),
+    AtomType.Media -> getDataStores[MediaAtom](mediaDynamoFormats)
+  )
+
+  def getDataStore(atomType: AtomType, version: Version) = {
+    val store = for {
+      atomDataStores <- AtomDataStores.dataStores.get(atomType)
+      atomDataStore <- atomDataStores.get(version)
+    } yield atomDataStore
+
+    Either.cond(store.isDefined, store.get, UnsupportedAtomTypeError)
   }
 }

--- a/app/db/AtomDataStores.scala
+++ b/app/db/AtomDataStores.scala
@@ -1,15 +1,14 @@
-package data
+package db
 
 import com.gu.atom.data._
 import com.gu.contentatom.thrift._
-import com.gu.contentatom.thrift.atom.media.MediaAtom
-import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
-import com.gu.scanamo.DynamoFormat
-import DynamoFormat._
-import cats.syntax.either._
-import com.gu.contentatom.thrift.atom.explainer.ExplainerAtom
 import com.gu.contentatom.thrift.atom.cta.CTAAtom
+import com.gu.contentatom.thrift.atom.explainer.ExplainerAtom
+import com.gu.contentatom.thrift.atom.media.MediaAtom
+import com.gu.scanamo.DynamoFormat
+import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
 import config.Config
+import cats.syntax.either._
 import models.{Live, Preview, UnsupportedAtomTypeError, Version}
 
 import scala.reflect.ClassTag

--- a/app/db/AtomWorkshopDB.scala
+++ b/app/db/AtomWorkshopDB.scala
@@ -1,13 +1,19 @@
 package db
 
 import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
-import com.gu.atom.data.{DynamoCompositeKey, DynamoDataStore}
+import com.gu.atom.data.{DataStoreError, DataStoreResult, DynamoCompositeKey, DynamoDataStore}
 import com.gu.contentatom.thrift.{Atom, AtomData, AtomType, ContentChangeDetails}
 import com.gu.contentatom.thrift.atom.cta.CTAAtom
 import com.gu.contentatom.thrift.atom.explainer.{DisplayType, ExplainerAtom}
 import com.gu.contentatom.thrift.atom.media.MediaAtom
 import play.api.Logger
 import cats.syntax.either._
+import com.gu.atom
+import models.{AtomAPIError, AtomWorkshopDynamoDatastoreError, CreateAtomDynamoError}
+import com.gu.fezziwig.CirceScroogeMacros._
+import io.circe._
+import io.circe.syntax._
+
 
 object AtomWorkshopDB {
 
@@ -26,22 +32,27 @@ object AtomWorkshopDB {
       contentChangeDetails = ContentChangeDetails(revision = 0L))
   }
 
+    def transformAtomLibResult[T](result: DataStoreResult.DataStoreResult[T]): Either[AtomAPIError, T] = result match {
+      case Left(e) => Left(AtomWorkshopDynamoDatastoreError(e.msg))
+      case Right(r:T) => Right(r)
+    }
+
   def createAtom(datastore: DynamoDataStore[_ >: ExplainerAtom with CTAAtom with MediaAtom], atomType: AtomType) = {
     val defaultAtom = buildDefaultAtom(atomType)
     Logger.info(s"Attempting to create atom of type ${atomType.name} with id ${defaultAtom.id}")
     try {
-      val r = Right(datastore.createAtom(buildKey(atomType, defaultAtom.id), defaultAtom))
+      val r = datastore.createAtom(buildKey(atomType, defaultAtom.id), defaultAtom)
       Logger.info(s"Successfully created atom of type ${atomType.name} with id ${defaultAtom.id}")
-      r
+      Right(transformAtomLibResult(r))
     } catch {
       case e: AmazonDynamoDBException =>
         Logger.error("Atom creation failed: ", e)
-        Left(e)
+        Left(CreateAtomDynamoError(defaultAtom.asJson.noSpaces, e.getMessage))
     }
   }
 
   def getAtom(datastore: DynamoDataStore[_ >: ExplainerAtom with CTAAtom with MediaAtom], atomType: AtomType, id: String) = {
-
+    transformAtomLibResult(datastore.getAtom(AtomWorkshopDB.buildKey(atomType, id)))
   }
 
 

--- a/app/db/AtomWorkshopDB.scala
+++ b/app/db/AtomWorkshopDB.scala
@@ -41,7 +41,7 @@ object AtomWorkshopDB {
   }
 
   def getAtom(datastore: DynamoDataStore[_ >: ExplainerAtom with CTAAtom with MediaAtom], atomType: AtomType, id: String) = {
-    datastore.getAtom(buildKey(atomType, id))
+
   }
 
 

--- a/app/db/AtomWorkshopDB.scala
+++ b/app/db/AtomWorkshopDB.scala
@@ -1,0 +1,48 @@
+package db
+
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
+import com.gu.atom.data.{DynamoCompositeKey, DynamoDataStore}
+import com.gu.contentatom.thrift.{Atom, AtomData, AtomType, ContentChangeDetails}
+import com.gu.contentatom.thrift.atom.cta.CTAAtom
+import com.gu.contentatom.thrift.atom.explainer.{DisplayType, ExplainerAtom}
+import com.gu.contentatom.thrift.atom.media.MediaAtom
+import play.api.Logger
+import cats.syntax.either._
+
+object AtomWorkshopDB {
+
+  def buildKey(atomType: AtomType, id: String) = DynamoCompositeKey(atomType.name, Some(id))
+
+  def buildDefaultAtom(atomType: AtomType) = {
+    val defaultAtoms: Map[AtomType, AtomData] = Map(
+      AtomType.Explainer -> AtomData.Explainer(ExplainerAtom("-", "-", DisplayType.Flat)),
+      AtomType.Cta -> AtomData.Cta(CTAAtom(""))
+    )
+
+    Atom(id = java.util.UUID.randomUUID.toString,
+      atomType = atomType,
+      defaultHtml = s"""<div class="atom-${atomType.name}"></div>""",
+      data = defaultAtoms(atomType),
+      contentChangeDetails = ContentChangeDetails(revision = 0L))
+  }
+
+  def createAtom(datastore: DynamoDataStore[_ >: ExplainerAtom with CTAAtom with MediaAtom], atomType: AtomType) = {
+    val defaultAtom = buildDefaultAtom(atomType)
+    Logger.info(s"Attempting to create atom of type ${atomType.name} with id ${defaultAtom.id}")
+    try {
+      val r = Right(datastore.createAtom(buildKey(atomType, defaultAtom.id), defaultAtom))
+      Logger.info(s"Successfully created atom of type ${atomType.name} with id ${defaultAtom.id}")
+      r
+    } catch {
+      case e: AmazonDynamoDBException =>
+        Logger.error("Atom creation failed: ", e)
+        Left(e)
+    }
+  }
+
+  def getAtom(datastore: DynamoDataStore[_ >: ExplainerAtom with CTAAtom with MediaAtom], atomType: AtomType, id: String) = {
+    datastore.getAtom(buildKey(atomType, id))
+  }
+
+
+}

--- a/app/models/APIResponse.scala
+++ b/app/models/APIResponse.scala
@@ -1,7 +1,5 @@
 package models
 
-import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
-import com.gu.atom.data.DataStoreError
 import play.api.Logger
 import io.circe._
 import io.circe.syntax._
@@ -21,11 +19,7 @@ object APIResponse extends Results {
   }
 
   def apply[T](result: Either[Exception, T])(implicit encoder: Encoder[T]): Result = {
-    val res = result.fold({
-      case e: DataStoreError => exceptionToResult(e)
-      case e: AmazonDynamoDBException => exceptionToResult(e)
-      case e: AtomAPIError => exceptionToResult(e)
-    }, r => Ok(r.asJson.noSpaces))
+    val res = result.fold(exceptionToResult(_), r => Ok(r.asJson.noSpaces))
     res.as("text/json")
   }
 }

--- a/app/models/APIResponse.scala
+++ b/app/models/APIResponse.scala
@@ -13,13 +13,13 @@ object AtomWorkshopAPIResponse{
 
 
 object APIResponse extends Results {
-  def exceptionToResult(e: Exception) = {
-    Logger.error(e.getMessage, e)
-    InternalServerError(AtomWorkshopAPIResponse(e.getMessage).asJson.noSpaces)
+  def apiErrorToResult(e: AtomAPIError) = {
+    Logger.error(e.msg)
+    InternalServerError(AtomWorkshopAPIResponse(e.msg).asJson.noSpaces)
   }
 
-  def apply[T](result: Either[Exception, T])(implicit encoder: Encoder[T]): Result = {
-    val res = result.fold(exceptionToResult(_), r => Ok(r.asJson.noSpaces))
+  def apply[T](result: Either[AtomAPIError, T])(implicit encoder: Encoder[T]): Result = {
+    val res = result.fold(apiErrorToResult(_), r => Ok(r.asJson.noSpaces))
     res.as("text/json")
   }
 }

--- a/app/models/APIResponse.scala
+++ b/app/models/APIResponse.scala
@@ -1,0 +1,31 @@
+package models
+
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
+import com.gu.atom.data.DataStoreError
+import play.api.Logger
+import io.circe._
+import io.circe.syntax._
+import play.api.mvc._
+import io.circe.generic.semiauto._
+
+case class AtomWorkshopAPIResponse(message: String)
+object AtomWorkshopAPIResponse{
+  implicit val atomWorkshopApiResponseEncoder: Encoder[AtomWorkshopAPIResponse] = deriveEncoder[AtomWorkshopAPIResponse]
+}
+
+
+object APIResponse extends Results {
+  def exceptionToResult(e: Exception) = {
+    Logger.error(e.getMessage, e)
+    InternalServerError(AtomWorkshopAPIResponse(e.getMessage).asJson.noSpaces)
+  }
+
+  def apply[T](result: Either[Exception, T])(implicit encoder: Encoder[T]): Result = {
+    val res = result.fold({
+      case e: DataStoreError => exceptionToResult(e)
+      case e: AmazonDynamoDBException => exceptionToResult(e)
+      case e: AtomAPIError => exceptionToResult(e)
+    }, r => Ok(r.asJson.noSpaces))
+    res.as("text/json")
+  }
+}

--- a/app/models/ClientConfig.scala
+++ b/app/models/ClientConfig.scala
@@ -1,4 +1,4 @@
-package model
+package models
 
 import org.cvogt.play.json.Jsonx
 

--- a/app/models/ClientConfig.scala
+++ b/app/models/ClientConfig.scala
@@ -1,11 +1,13 @@
 package models
 
-import org.cvogt.play.json.Jsonx
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto._
 
 case class ClientConfig(
                          username: String
                        )
 
 object ClientConfig {
-  implicit val clientConfigFormat = Jsonx.formatCaseClass[ClientConfig]
+  implicit val clientConfigEncoder: Encoder[ClientConfig] = deriveEncoder
+  implicit val clientConfigDecoder: Decoder[ClientConfig] = deriveDecoder
 }

--- a/app/models/Errors.scala
+++ b/app/models/Errors.scala
@@ -1,8 +1,9 @@
 package models
 
-sealed abstract class AtomAPIError(val msg: String) extends Exception(msg)
+sealed abstract class AtomAPIError(val msg: String)
 
 case object InvalidAtomTypeError extends AtomAPIError("Atom type not valid - did you make a typo? Correct examples: 'explainer', 'cta', 'media")
 case object UnsupportedAtomTypeError extends AtomAPIError("Atom type not supported. Currently supported types: unknown")
-case class UnexpectedDynamoError(info: String) extends AtomAPIError(info)
-case object UnknownAPIError extends AtomAPIError("Atom workshop API Threw an error! Sorry, I've no idea why")
+case class CreateAtomDynamoError(atomJson: String, message: String) extends AtomAPIError(s"Error thrown by Dynamo when attempting to create atom. JSON of atom: $atomJson, error message: $message")
+
+case class AtomWorkshopDynamoDatastoreError(message: String) extends AtomAPIError(message)

--- a/app/models/Errors.scala
+++ b/app/models/Errors.scala
@@ -1,0 +1,6 @@
+package models
+
+sealed abstract class AtomAPIError(val msg: String) extends Exception(msg)
+
+case object InvalidAtomTypeError extends AtomAPIError("Atom type not valid - did you make a typo? Correct examples: 'explainer', 'cta', 'media")
+case object UnsupportedAtomTypeError extends AtomAPIError("Atom type not supported. Currently supported types: unknown")

--- a/app/models/Errors.scala
+++ b/app/models/Errors.scala
@@ -4,3 +4,5 @@ sealed abstract class AtomAPIError(val msg: String) extends Exception(msg)
 
 case object InvalidAtomTypeError extends AtomAPIError("Atom type not valid - did you make a typo? Correct examples: 'explainer', 'cta', 'media")
 case object UnsupportedAtomTypeError extends AtomAPIError("Atom type not supported. Currently supported types: unknown")
+case class UnexpectedDynamoError(info: String) extends AtomAPIError(info)
+case object UnknownAPIError extends AtomAPIError("Atom workshop API Threw an error! Sorry, I've no idea why")

--- a/app/models/Version.scala
+++ b/app/models/Version.scala
@@ -1,0 +1,6 @@
+package models
+
+sealed trait Version
+
+case object Preview extends Version
+case object Live extends Version

--- a/app/util/HelperFunctions.scala
+++ b/app/util/HelperFunctions.scala
@@ -1,0 +1,17 @@
+package util
+
+import com.gu.contentatom.thrift.AtomType
+import models._
+
+
+object HelperFunctions {
+  def getVersion(version: String): Version = version match {
+    case "preview" => Preview
+    case "live" => Live
+  }
+
+  def validateAtomType(atomType: String): Either[AtomAPIError, AtomType] = {
+    val t = AtomType.valueOf(atomType)
+    Either.cond(t.isDefined, t.get, InvalidAtomTypeError)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,9 @@ libraryDependencies ++= Seq(
   "com.gu"                   %% "configuration-magic-core"    % "1.3.0",
   "com.gu"                   %  "kinesis-logback-appender"    % "1.3.0",
   "com.gu"                   %% "pan-domain-auth-play_2-5"    % "0.4.1",
-  "org.cvogt"                %% "play-json-extensions"      % "0.6.0",
-  "net.logstash.logback"     %  "logstash-logback-encoder"    % "4.2"
+  "org.cvogt"                %% "play-json-extensions"        % "0.6.0",
+  "net.logstash.logback"     %  "logstash-logback-encoder"    % "4.2",
+  "com.gu"                   % "fezziwig"                    % "0.1.0"
 )
 
 resolvers ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -15,9 +15,8 @@ libraryDependencies ++= Seq(
   "com.gu"                   %% "configuration-magic-core"    % "1.3.0",
   "com.gu"                   %  "kinesis-logback-appender"    % "1.3.0",
   "com.gu"                   %% "pan-domain-auth-play_2-5"    % "0.4.1",
-  "org.cvogt"                %% "play-json-extensions"        % "0.6.0",
   "net.logstash.logback"     %  "logstash-logback-encoder"    % "4.2",
-  "com.gu"                   % "fezziwig"                    % "0.1.0"
+  "com.gu"                   %  "fezziwig"                    % "0.1.0"
 )
 
 resolvers ++= Seq(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -6,14 +6,3 @@ play.crypto.secret="Replace me, please!"
 
 panda.system="atom-workshop"
 
-aws {
-  profile="composer"
-  dynamo {
-    preview {
-      tableName = "atom-workshop-preview-DEV"
-    }
-    live {
-      tableName = "atom-worshop-live-DEV"
-    }
-  }
-}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -6,3 +6,5 @@ play.crypto.secret="Replace me, please!"
 
 panda.system="atom-workshop"
 
+// No stage-specific config should go here!
+// DEV config goes in ~/.gu/.configuration-magic/atom-workshop.conf and CODE/PROD config lives in dynamo

--- a/conf/routes
+++ b/conf/routes
@@ -9,7 +9,8 @@ GET     /reauth                     controllers.Login.reauth
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
 
 
-GET  /api/:atomType/:id/preview             controllers.App.getAtom(atomType: String, id: String, version = "preview")
+GET  /api/preview/:atomType/:id/    controllers.App.getAtom(atomType: String, id: String, version = "preview")
+GET  /api/live/:atomType/:id/       controllers.App.getAtom(atomType: String, id: String, version = "live")
 
-# We only ever create into the preview table so no version needed here
-POST  /api/:atomType             controllers.App.createAtom(atomType: String)
+# We only ever create into the preview table so no version passed through here (but kept in route to match the pattern!)
+POST  /api/preview/:atomType               controllers.App.createAtom(atomType: String)

--- a/conf/routes
+++ b/conf/routes
@@ -7,3 +7,9 @@ GET     /reauth                     controllers.Login.reauth
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
+
+
+GET  /api/:atomType/:id/preview             controllers.App.getAtom(atomType: String, id: String, version = "preview")
+
+# We only ever create into the preview table so no version needed here
+POST  /api/:atomType             controllers.App.createAtom(atomType: String)


### PR DESCRIPTION
PUT still to come. Using the lovely API design suggested by @adamnfish. 

As part of this I had to write rather a lot of boilerplate in AtomDataStores.scala, hopefully we can kill this off at some point in the future - its about 6 lines per type of atom so not terrible but not ideal.

(@ShaunYearStrong - as we have to use Circe for nice Atom to Json serialising I thought I'd be consistent and set up to use that everywhere, and so ended up removing the play json lib you added. Let me know if this breaks something and I'll put it back!)