### PR TITLE
Added createAtom functionality

### DIFF
--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -45,8 +45,8 @@ class App(val wsClient: WSClient) extends Controller with PanDomainAuthActions {
       for {
         atomType <- validateAtomType(atomType)
         ds <- AtomDataStores.getDataStore(atomType, Preview)
-        result <- AtomWorkshopDB.createAtom(ds, atomType, req.user)
-      } yield AtomWorkshopAPIResponse("Atom creation successful")
+        atom <- AtomWorkshopDB.createAtom(ds, atomType, req.user)
+      } yield atom
     }
   }
 

--- a/app/db/AtomWorkshopDB.scala
+++ b/app/db/AtomWorkshopDB.scala
@@ -31,7 +31,7 @@ object AtomWorkshopDB {
     try {
       val r = datastore.createAtom(buildKey(atomType, defaultAtom.id), defaultAtom)
       Logger.info(s"Successfully created atom of type ${atomType.name} with id ${defaultAtom.id}")
-      Right(transformAtomLibResult(r))
+      getAtom(datastore, atomType, defaultAtom.id)
     } catch {
       case e: Exception => processException(e)
     }

--- a/app/util/AtomElementBuilders.scala
+++ b/app/util/AtomElementBuilders.scala
@@ -30,7 +30,7 @@ object AtomElementBuilders {
   def buildDefaultAtom(atomType: AtomType, user: PandaUser) = {
     val defaultAtoms: Map[AtomType, AtomData] = Map(
       AtomType.Explainer -> AtomData.Explainer(ExplainerAtom("-", "-", DisplayType.Flat)),
-      AtomType.Cta -> AtomData.Cta(CTAAtom(""))
+      AtomType.Cta -> AtomData.Cta(CTAAtom("-"))
     )
 
     Atom(id = java.util.UUID.randomUUID.toString,

--- a/public/js/BaseApp.js
+++ b/public/js/BaseApp.js
@@ -4,7 +4,7 @@ import {Router, Route, browserHistory, IndexRedirect} from 'react-router';
 
 import {Page} from './components/Page';
 import {AtomCreateTypeSelect} from './components/AtomCreate/AtomCreateTypeSelect';
-import {AtomCreateGenericInfo} from './components/AtomCreate/AtomCreateGenericInfo';
+import AtomCreateGenericInfo from './components/AtomCreate/AtomCreateGenericInfo';
 import {AtomEdit} from './components/AtomEdit/AtomEdit';
 import {AtomStats} from './components/AtomStats/AtomStats';
 

--- a/public/js/actions/AtomActions/createAtom.js
+++ b/public/js/actions/AtomActions/createAtom.js
@@ -1,3 +1,5 @@
+import {browserHistory} from 'react-router';
+
 import AtomsApi from '../../services/AtomsApi';
 import {logError} from '../../util/logger';
 
@@ -31,8 +33,10 @@ export function createAtom(atomType) {
   return dispatch => {
     dispatch(requestAtomCreate(atomType));
     return AtomsApi.createAtom(atomType)
+        .then(res => res.json())
         .then(atom => {
           dispatch(receiveAtomCreate(atom));
+          browserHistory.push(`/atoms/${atom.id}/edit`);
         })
         .catch(error => dispatch(errorCreatingAtom(error)));
   };

--- a/public/js/components/AtomCreate/AtomCreateGenericInfo.js
+++ b/public/js/components/AtomCreate/AtomCreateGenericInfo.js
@@ -4,13 +4,14 @@ import {getAtomByType} from '../../constants/atomData';
 import {AtomTypeCard} from '../AtomTypeCard/AtomTypeCard.js';
 import FormFieldTextInput from '../FormFields/FormFieldTextInput';
 
-import {logInfo} from '../../util/logger';
-
-export class AtomCreateGenericInfo extends React.Component {
+class AtomCreateGenericInfo extends React.Component {
 
   static propTypes = {
     routeParams: PropTypes.shape({
       atomType: PropTypes.String
+    }).isRequired,
+    atomActions: PropTypes.shape({
+      createAtom: PropTypes.func.isRequired
     }).isRequired
   }
 
@@ -24,8 +25,8 @@ export class AtomCreateGenericInfo extends React.Component {
     });
   }
 
-  createAtom = (e) => {
-    logInfo("This is where we create the atom", e);
+  triggerAtomCreate = () => {
+    this.props.atomActions.createAtom(this.props.routeParams.atomType);
   }
 
   render () {
@@ -53,9 +54,28 @@ export class AtomCreateGenericInfo extends React.Component {
           />
         </div>
         <div className="create__buttons">
-          <button className="btn" onClick={this.createAtom}>Create Atom</button>
+          <button className="btn" onClick={this.triggerAtomCreate}>Create Atom</button>
         </div>
       </div>
     );
   }
 }
+
+//REDUX CONNECTIONS
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import * as createAtomActions from '../../actions/AtomActions/createAtom.js';
+
+function mapStateToProps(state) {
+  return {
+    config: state.config
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    atomActions: bindActionCreators(Object.assign({}, createAtomActions), dispatch)
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(AtomCreateGenericInfo);

--- a/public/js/services/AtomsApi.js
+++ b/public/js/services/AtomsApi.js
@@ -7,7 +7,8 @@ export default {
       new Request(
         `/api/preview/${atomType}/${atomId}`,
         {
-          method: 'get'
+          method: 'get',
+          credentials: 'same-origin'
         }
       )
     );
@@ -19,7 +20,8 @@ export default {
       new Request(
         `/api/preview/${atomType}`,
         {
-          method: 'post'
+          method: 'post',
+          credentials: 'same-origin'
         }
       )
     );


### PR DESCRIPTION
This adds a working createAtom functionality. Only functional with CTA and Explainers while work is being done for non-complete atoms. I've modified the create atom endpoint so it returns the full atom on a successful create

Important things from this... 

 - `fetch` requires us to pass `credentials: 'same-origin'`
 - we need to `res.json()` the result