### PR TITLE
Pass require prop into Modal test

### DIFF
--- a/public/js/components/Utilities/Modal.spec.js
+++ b/public/js/components/Utilities/Modal.spec.js
@@ -5,7 +5,7 @@ import {shallow} from 'enzyme';
 
 test('Should render null when closed', () => {
   const component = renderer.create(
-    <Modal isOpen={false}><div>Modal Contents</div></Modal>
+    <Modal isOpen={false} dismiss={() => {}}><div>Modal Contents</div></Modal>
   );
   let tree = component.toJSON();
   expect(tree).toMatchSnapshot();
@@ -13,7 +13,7 @@ test('Should render null when closed', () => {
 
 test('Should render contents when open', () => {
   const component = renderer.create(
-    <Modal isOpen={true}><div>Modal Contents</div></Modal>
+    <Modal isOpen={true} dismiss={() => {}}><div>Modal Contents</div></Modal>
   );
   let tree = component.toJSON();
   expect(tree).toMatchSnapshot();

--- a/public/js/components/Utilities/__snapshots__/Modal.spec.js.snap
+++ b/public/js/components/Utilities/__snapshots__/Modal.spec.js.snap
@@ -1,7 +1,7 @@
 exports[`test Should render contents when open 1`] = `
 <div
   className="modal"
-  onClick={undefined}>
+  onClick={[Function]}>
   <div
     className="modal__content"
     onClick={[Function]}>
@@ -9,7 +9,7 @@ exports[`test Should render contents when open 1`] = `
       className="modal__content__header">
       <button
         className="i-cross modal__dismiss"
-        onClick={undefined}>
+        onClick={[Function]}>
         Close
       </button>
     </div>


### PR DESCRIPTION
Dismiss is now a required prop for the `<Modal />` component, this passes through the prop in the test (even though it's not used)