### PR TITLE
Require panda-session be loaded through babel-loader

### DIFF
--- a/conf/webpack-devserver.conf.js
+++ b/conf/webpack-devserver.conf.js
@@ -1,3 +1,6 @@
+/* global module:false, __dirname:false */
+
+
 const { resolve } = require('path');
 const webpack = require('webpack');
 
@@ -28,6 +31,11 @@ module.exports = {
             {
                 test:    /\.js$/,
                 exclude: /node_modules/,
+                loaders: ['babel-loader']
+            },
+            {
+                test:    /\.js$/,
+                include: [resolve(__dirname, "../node_modules/panda-session")],
                 loaders: ['babel-loader']
             },
             {

--- a/conf/webpack.conf.js
+++ b/conf/webpack.conf.js
@@ -1,3 +1,5 @@
+/* global module:false, __dirname:false */
+
 var path = require('path');
 var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
@@ -9,6 +11,11 @@ module.exports = {
             {
                 test:    /\.js$/,
                 exclude: /node_modules/,
+                loaders: ['babel-loader']
+            },
+            {
+                test:    /\.js$/,
+                include: [path.resolve(__dirname, "../node_modules/panda-session")],
                 loaders: ['babel-loader']
             },
             {


### PR DESCRIPTION
Fixing the build errors, #39 actually used panda-session (it was previously being excluded), when it hit UglifyJS the ES6-ness caused the build to fail. This ensures it is passed through babel