### PR TITLE
Reduce no. of PROD instances to 1 whilst nobody is using atom workshop.

### DIFF
--- a/cloudformation/AtomWorkshop.yml
+++ b/cloudformation/AtomWorkshop.yml
@@ -60,13 +60,13 @@ Mappings:
       PROD: 0.0.0.0/0
     DesiredCapacity:
       CODE: 1
-      PROD: 3
+      PROD: 1
     MaxSize:
       CODE: 2
       PROD: 6
     MinSize:
       CODE: 1
-      PROD: 3
+      PROD: 1
 Resources:
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration


### PR DESCRIPTION
Following this change, I'm going to set up continuous deployment to PROD.