### PR TITLE
Improve resiliency when contentChangeDetails incomplete.

### DIFF
--- a/public/js/components/AtomEdit/AtomEditHeader.js
+++ b/public/js/components/AtomEdit/AtomEditHeader.js
@@ -22,8 +22,8 @@ export default class AtomEditHeader extends React.Component {
     }
 
     const date = new Date(dateInfo.date);
-    return `${date.toLocaleDateString()} at ${date.toLocaleTimeString()}` +
-            ` by ${dateInfo.user.firstName} ${dateInfo.user.lastName}`;
+    const nameOfUser = dateInfo.user ? ` by ${dateInfo.user.firstName} ${dateInfo.user.lastName}` : '';
+    return `${date.toLocaleDateString()} at ${date.toLocaleTimeString()} ${nameOfUser}`;
   }
 
 

--- a/public/js/components/Header/Header.js
+++ b/public/js/components/Header/Header.js
@@ -39,10 +39,17 @@ class Header extends React.Component {
     this.props.atomActions.takeDownAtom(this.props.atom);
   }
 
+  timeSinceLastModified = () => {
+    if (this.props.atom.contentChangeDetails.created || this.props.atom.contentChangeDetails.lastModified) {
+      const dateNow = Date.now();
+      const lastModified = this.props.atom.contentChangeDetails.lastModified ? this.props.atom.contentChangeDetails.lastModified.date : this.props.atom.contentChangeDetails.created.date;
+      return distanceInWords(dateNow, lastModified, {addSuffix: true});
+    }
+    return false;
+  }
+
   renderSaveState = () => {
-    const dateNow = Date.now();
-    const lastModified = this.props.atom.contentChangeDetails.lastModified ? this.props.atom.contentChangeDetails.lastModified.date : this.props.atom.contentChangeDetails.created.date;
-    const timeSinceLastModified = distanceInWords(dateNow, lastModified, {addSuffix: true});
+
 
     if(this.props.saveState.saving === saveStateVals.inprogress) {
       return (
@@ -50,7 +57,7 @@ class Header extends React.Component {
       );
     }
     return (
-      <span><span className="save-state">Saved</span> {timeSinceLastModified}</span>
+      <span><span className="save-state">Saved</span> {this.timeSinceLastModified()}</span>
     );
   }
 

--- a/public/js/util/publishState.js
+++ b/public/js/util/publishState.js
@@ -9,7 +9,7 @@ const publishState = (atom) => {
       };
     }
 
-    if (atom.contentChangeDetails.published.date >= atom.contentChangeDetails.lastModified.date) {
+    if (atom.contentChangeDetails.lastModified && atom.contentChangeDetails.published.date >= atom.contentChangeDetails.lastModified.date) {
       return {
         id: 'published',
         text: 'Published'


### PR DESCRIPTION
We'll need this to cope with cta atoms which are lacking contentChangeDetails fields.