### PR TITLE
Add fields to cta editor to match cta maker

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/CTAEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/CTAEditor.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 
 import {ManagedForm, ManagedField} from '../../ManagedEditor';
 import FormFieldTextInput from '../../FormFields/FormFieldTextInput';
+import FormFieldArrayWrapper from '../../FormFields/FormFieldArrayWrapper';
 import {isHttpsUrl} from '../../../util/validators';
 
 export class CTAEditor extends React.Component {
@@ -21,9 +22,11 @@ export class CTAEditor extends React.Component {
         <ManagedField fieldLocation="data.cta.url" name="Link Url" isRequired={true}>
           <FormFieldTextInput/>
         </ManagedField>
-          <ManagedField fieldLocation="labels" name="Campaign">
-              <FormFieldTextInput />
-          </ManagedField>
+        <ManagedField fieldLocation="labels" name="Campaign Labels">
+          <FormFieldArrayWrapper>
+            <FormFieldTextInput />
+          </FormFieldArrayWrapper>
+        </ManagedField>
         <ManagedField fieldLocation="data.cta.backgroundImage" name="Background Image Url" customValidation={[isHttpsUrl]}>
           <FormFieldTextInput />
         </ManagedField>

--- a/public/js/components/AtomEdit/CustomEditors/CTAEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/CTAEditor.js
@@ -21,13 +21,16 @@ export class CTAEditor extends React.Component {
         <ManagedField fieldLocation="data.cta.url" name="Link Url" isRequired={true}>
           <FormFieldTextInput/>
         </ManagedField>
-        <ManagedField fieldLocation="data.cta.btnText" name="Button Text">
-          <FormFieldTextInput />
-        </ManagedField>
+          <ManagedField fieldLocation="labels" name="Campaign">
+              <FormFieldTextInput />
+          </ManagedField>
         <ManagedField fieldLocation="data.cta.backgroundImage" name="Background Image Url" customValidation={[isHttpsUrl]}>
           <FormFieldTextInput />
         </ManagedField>
-        <ManagedField fieldLocation="data.cta.label" name="Background Text">
+        <ManagedField fieldLocation="data.cta.btnText" name="Button Text">
+          <FormFieldTextInput />
+        </ManagedField>
+        <ManagedField fieldLocation="data.cta.label" name="Label">
           <FormFieldTextInput />
         </ManagedField>
         <ManagedField fieldLocation="data.cta.trackingcode" name="Tracking Code">


### PR DESCRIPTION
The background text field was incorrectly named so I've renamed that. We were also missing the campaign field, which is stored in the top level labels array. In CTA maker it's not an array input field - just a single item, but I'm hoping its ok to do it as an array here!

CTA Maker:
https://cta-atom-maker.code.dev-gutools.co.uk/#/atom/96e3af8c-87e6-4706-87a9-8a29e82361ee
CAPI representation:
http://content.code.dev-guardianapis.com/atom/cta/96e3af8c-87e6-4706-87a9-8a29e82361ee

![screen shot 2017-03-17 at 10 59 53](https://cloud.githubusercontent.com/assets/3606555/24040566/a1030f34-0b01-11e7-8db8-2f1dba158719.png)
