### PR TITLE
Handle presence errors

### DIFF
--- a/public/js/components/FormFields/FormFieldScribeEditor.js
+++ b/public/js/components/FormFields/FormFieldScribeEditor.js
@@ -34,7 +34,7 @@ export default class FormFieldsScribeEditor extends React.Component {
           <span className="form__message__text">{wordCount} words</span>
           {tooLong ? <span className="form__message__text--error"> (too long)</span>: false}
         </div>
-    )
+    );
   }
 
 

--- a/public/js/services/presence.js
+++ b/public/js/services/presence.js
@@ -8,7 +8,7 @@ export const subscribeToPresence = (atomId, atomType) => {
 
     presenceClient.on("connection.open", () => {
       presenceClient.subscribe(`${atomType}-${atomId}`);
-      enterPresence(atomId, atomType);
+      presenceClient.enter(`${atomType}-${atomId}`, 'document');
     });
 
     presenceClient.on('visitor-list-updated', presence => updatePresence(presence));
@@ -18,7 +18,12 @@ export const subscribeToPresence = (atomId, atomType) => {
 export const enterPresence = (atomId, atomType) => {
   const store = getStore();
   const presenceClient = store.getState().presenceClient;
-  presenceClient.enter(`${atomType}-${atomId}`, 'document');
+  const presence = store.getState().presence;
+  if(presence !== null) {
+    presenceClient.enter(`${atomType}-${atomId}`, 'document');
+  } else {
+    throw new Error('No Presence connection found');
+  }
 };
 
 const updatePresence = (presence) => {


### PR DESCRIPTION
You get loads of errors when updating fields if presence hasn't connected. This stops that but allow presence to handle it's own WS retries as per usual.