### PR TITLE
space header elements properly

### DIFF
--- a/public/styles/layout/_toolbar.scss
+++ b/public/styles/layout/_toolbar.scss
@@ -11,6 +11,7 @@ $toolbarHeight: 50px;
   display: flex;
   z-index: 1;
   border-bottom: 1px solid $greyBorderColor;
+  justify-content: space-between;
 
   box-shadow: 0px 1px 2px $color200Grey;
 


### PR DESCRIPTION
before:
![picture 146](https://cloud.githubusercontent.com/assets/2104095/24245119/7835701c-0fb9-11e7-8c97-1a8e4b18fff4.png)
after:
![picture 147](https://cloud.githubusercontent.com/assets/2104095/24245120/7845ead2-0fb9-11e7-8239-2086481064f7.png)
