### PR TITLE
Ensure trackingCode is persisted and sent to capi.

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/CTAEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/CTAEditor.js
@@ -37,7 +37,7 @@ export class CTAEditor extends React.Component {
         <ManagedField fieldLocation="data.cta.label" name="Label">
           <FormFieldTextInput />
         </ManagedField>
-        <ManagedField fieldLocation="data.cta.trackingcode" name="Tracking Code">
+        <ManagedField fieldLocation="data.cta.trackingCode" name="Tracking Code">
           <FormFieldTextInput />
         </ManagedField>
       </ManagedForm>


### PR DESCRIPTION
Currently the tracking code form field in the cta editor is broken - the data isn't saved. This fixes that.