### PR TITLE
Tweak queryParams for edge cases on search

### DIFF
--- a/public/js/actions/AtomListActions/getAtomList.js
+++ b/public/js/actions/AtomListActions/getAtomList.js
@@ -23,7 +23,7 @@ function errorReceivingAtomList(error) {
     logError(error);
     return {
         type:       'SHOW_ERROR',
-        message:    'Could not get atom LIST',
+        message:    'Could not get Atom list',
         error:      error,
         receivedAt: Date.now()
     };

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -23,6 +23,7 @@ function extractConfigFromPage() {
 
 const store = configureStore();
 const history = syncHistoryWithStore(browserHistory, store);
+
 const config = extractConfigFromPage();
 const presenceClient = config.presenceEnabled ? configurePresence(config.presenceEndpointURL, config.user) : {};
 

--- a/public/js/components/AtomList/AtomList.js
+++ b/public/js/components/AtomList/AtomList.js
@@ -44,9 +44,9 @@ class AtomList extends React.Component {
     this.triggerSearch();
   }
 
-  componentWillReceiveProps(props) {
-    if (!_isEqual(props.queryParams, this.props.queryParams)) {
-      this.triggerSearch(props.queryParams);
+  componentWillReceiveProps(newProps) {
+    if (!_isEqual(newProps.queryParams, this.props.queryParams)) {
+      this.triggerSearch(Object.assign({}, searchParams, newProps.queryParams));
     }
   }
 

--- a/public/js/util/store.js
+++ b/public/js/util/store.js
@@ -11,11 +11,12 @@ import {
 
 
 export function configureStore() {
+  const router = routerMiddleware(browserHistory);
   const store = createStore(
     rootReducer,
     compose(
       applyMiddleware(thunkMiddleware),
-      applyMiddleware(routerMiddleware(browserHistory)),
+      applyMiddleware(router),
       applyMiddleware(updateUrlFromStateChangeMiddleware),
       applyMiddleware(updateStateFromUrlChangeMiddleware),
       window.devToolsExtension ? window.devToolsExtension() : f => f


### PR DESCRIPTION
The searchParams were being overwritten with an empty object. This merges that empty object with the existing one to stop errors on the managed search fields.

Bonus grammar tweaks and cleaner initialisation of the routerMiddleware.