### PR TITLE
Storyquestions default HTML snippet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ target
 .DS_Store
 logs/
 node_modules/
-
+.ensime*
 public/build

--- a/app/util/AtomElementBuilders.scala
+++ b/app/util/AtomElementBuilders.scala
@@ -51,7 +51,7 @@ object AtomElementBuilders {
   }
 
   def buildDefaultHtml(atomType: AtomType, atomData: AtomData): String = {
-    s"""<div class="atom-${atomType.name}">${buildHtml(atomType, atomData)}</div>"""
+    s"""<div class="atom-${atomType.name}">${buildHtml(atomType, atomData).getOrElse("")}</div>"""
   }
 
   def buildHtml(atomType: AtomType, atomData: AtomData): Option[String] = atomType match {

--- a/app/util/AtomElementBuilders.scala
+++ b/app/util/AtomElementBuilders.scala
@@ -44,29 +44,25 @@ object AtomElementBuilders {
       title = createAtomFields.flatMap(_.title),
       id = java.util.UUID.randomUUID.toString,
       atomType = atomType,
-      defaultHtml = createAtomFields.flatMap(_.defaultHtml).getOrElse(buildHtml(atomType = atomType, atomData = defaultAtoms(atomType))),
+      defaultHtml = createAtomFields.flatMap(_.defaultHtml).getOrElse(buildDefaultHtml(atomType = atomType, atomData = defaultAtoms(atomType))),
       data = defaultAtoms(atomType),
       contentChangeDetails = buildContentChangeDetails(user, None, updateCreated = true)
     )
   }
 
-  // this is just a stub - will eventually need to generate default HTML for all the atom types we support
-  def buildHtml(atomType: AtomType, atomData: AtomData): String = atomType match {
+  def buildDefaultHtml(atomType: AtomType, atomData: AtomData): String = {
+    s"""<div class="atom-${atomType.name}">${buildHtml(atomType, atomData)}</div>"""
+  }
+
+  def buildHtml(atomType: AtomType, atomData: AtomData): Option[String] = atomType match {
     case AtomType.Storyquestions => buildStoryQuestionsHtml(atomData)
-    case _ => buildDefaultHtml(atomType)
+    case _ => None
   }
 
-  def buildStoryQuestionsHtml(sqData: AtomData): String = {
-    val questions: Option[String] = for {
-      eqs <- sqData.asInstanceOf[AtomData.Storyquestions].storyquestions.editorialQuestions
-    } yield {
-      eqs flatMap (_.questions map { q => s"<li>${q.questionText}</li>" }) mkString ""
-    }
-
-    questions map ("<ul>" ++ _ ++ "</ul>") getOrElse ""
-  }
-
-  def buildDefaultHtml(atomType: AtomType): String = {
-    s"""<div class="atom-${atomType.name}"></div>"""
+  def buildStoryQuestionsHtml(sqData: AtomData): Option[String] = for {
+    eqs <- sqData.asInstanceOf[AtomData.Storyquestions].storyquestions.editorialQuestions
+  } yield {
+    val list = eqs flatMap (_.questions map { q => s"<li>${q.questionText}</li>" }) mkString ""
+    "<ul>" ++ list ++ "</ul>"
   }
 }

--- a/app/util/AtomElementBuilders.scala
+++ b/app/util/AtomElementBuilders.scala
@@ -44,14 +44,29 @@ object AtomElementBuilders {
       title = createAtomFields.flatMap(_.title),
       id = java.util.UUID.randomUUID.toString,
       atomType = atomType,
-      defaultHtml = createAtomFields.flatMap(_.defaultHtml).getOrElse(buildDefaultHtml(atomType = atomType, atomData = defaultAtoms(atomType))),
+      defaultHtml = createAtomFields.flatMap(_.defaultHtml).getOrElse(buildHtml(atomType = atomType, atomData = defaultAtoms(atomType))),
       data = defaultAtoms(atomType),
       contentChangeDetails = buildContentChangeDetails(user, None, updateCreated = true)
     )
   }
 
   // this is just a stub - will eventually need to generate default HTML for all the atom types we support
-  def buildDefaultHtml(atomType: AtomType, atomData: AtomData): String = {
+  def buildHtml(atomType: AtomType, atomData: AtomData): String = atomType match {
+    case AtomType.Storyquestions => buildStoryQuestionsHtml(atomData)
+    case _ => buildDefaultHtml(atomType)
+  }
+
+  def buildStoryQuestionsHtml(sqData: AtomData): String = {
+    val questions: Option[String] = for {
+      eqs <- sqData.asInstanceOf[AtomData.Storyquestions].storyquestions.editorialQuestions
+    } yield {
+      eqs flatMap (_.questions map { q => s"<li>${q.questionText}</li>" }) mkString ""
+    }
+
+    questions map ("<ul>" ++ _ ++ "</ul>") getOrElse ""
+  }
+
+  def buildDefaultHtml(atomType: AtomType): String = {
     s"""<div class="atom-${atomType.name}"></div>"""
   }
 }

--- a/app/util/AtomUpdateOperations.scala
+++ b/app/util/AtomUpdateOperations.scala
@@ -13,7 +13,7 @@ object AtomUpdateOperations {
   def updateTopLevelFields(atom: Atom, user: User, publish: Boolean = false): Atom =
     atom.copy(
       contentChangeDetails = buildContentChangeDetails(user, Some(atom.contentChangeDetails), updateLastModified = true, updatePublished = publish),
-      defaultHtml = buildHtml(atom.atomType, atom.data)
+      defaultHtml = buildDefaultHtml(atom.atomType, atom.data)
     )
 
   def updateAtomFromJson(atom: Atom, json: Json, user: User): Either[AtomAPIError, Atom] = jsonToAtom(atom.asJson.deepMerge(json))

--- a/app/util/AtomUpdateOperations.scala
+++ b/app/util/AtomUpdateOperations.scala
@@ -13,7 +13,7 @@ object AtomUpdateOperations {
   def updateTopLevelFields(atom: Atom, user: User, publish: Boolean = false): Atom =
     atom.copy(
       contentChangeDetails = buildContentChangeDetails(user, Some(atom.contentChangeDetails), updateLastModified = true, updatePublished = publish),
-      defaultHtml = buildDefaultHtml(atom.atomType, atom.data)
+      defaultHtml = buildHtml(atom.atomType, atom.data)
     )
 
   def updateAtomFromJson(atom: Atom, json: Json, user: User): Either[AtomAPIError, Atom] = jsonToAtom(atom.asJson.deepMerge(json))


### PR DESCRIPTION
This is in conjunction with the work done [here](https://github.com/guardian/flexible-content/pull/2821) to preview a story questions atom in the suggestions.

I expect this is not as idiomatic as this project's authors would like it to be, so please do comment.

One question I will answer preemptively is that I followed the thread of `CreateAtomFields.defaultHtml` and it seems to be coming from [some React component](https://github.com/guardian/atom-workshop/blob/master/public/js/actions/AtomActions/createAtom.js#L32), and so I didn't want to define the default HTML there because it felt really fragile.