### PR TITLE
Simplify story questions

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/QuestionSet.js
+++ b/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/QuestionSet.js
@@ -30,9 +30,14 @@ export class StoryQuestionsQuestionSet extends React.Component {
   }
 
   render () {
+    const value = this.props.fieldValue || {
+      questionSetId: "",
+      questionSetTitle: "",
+      questions: []
+    };
     return (
       <div className="form__field">
-        <ManagedForm data={this.props.fieldValue} updateData={this.updateQuestionSet} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="storyquestionsEditor">
+        <ManagedForm data={value} updateData={this.updateQuestionSet} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="storyquestionsEditor">
           <ManagedField fieldLocation="questions" name="Questions" isRequired={true}>
             <FormFieldArrayWrapper>
               <StoryQuestionsQuestion />

--- a/public/js/components/AtomEdit/CustomEditors/StoryQuestionsEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/StoryQuestionsEditor.js
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react';
 import FormFieldTagPicker from '../../FormFields/FormFieldTagPicker';
 import FormFieldTextInput from '../../FormFields/FormFieldTextInput';
-import FormFieldArrayWrapper from '../../FormFields/FormFieldArrayWrapper';
 import {StoryQuestionsQuestionSet} from './StoryQuestionFields/QuestionSet';
 import {ManagedField, ManagedForm} from '../../ManagedEditor';
 import {atomPropType} from '../../../constants/atomPropType';
@@ -25,10 +24,9 @@ export class StoryQuestionsEditor extends React.Component {
           <ManagedField fieldLocation="data.storyquestions.relatedStoryId" name="Related Tag" isRequired={true}>
             <FormFieldTagPicker/>
           </ManagedField>
-          <ManagedField fieldLocation="data.storyquestions.editorialQuestions" name="Editorial Questions">
-            <FormFieldArrayWrapper>
-              <StoryQuestionsQuestionSet onFormErrorsUpdate={this.props.onFormErrorsUpdate} />
-            </FormFieldArrayWrapper>
+          /* Always exactly one QuestionSet in editorialQuestions, as we hide this model in the UI */
+          <ManagedField fieldLocation="data.storyquestions.editorialQuestions[0]" name="Editorial Questions">
+            <StoryQuestionsQuestionSet onFormErrorsUpdate={this.props.onFormErrorsUpdate} />
           </ManagedField>
         </ManagedForm>
       </div>


### PR DESCRIPTION
Hides the `QuestionSet` model from users, as this is not required by Editorial - they just need to add questions.

![picture 6](https://cloud.githubusercontent.com/assets/1513454/26056378/020f5582-396d-11e7-91f1-9fd762d06b43.png)


@shaundillon 