### PR TITLE
filter empty words

### DIFF
--- a/public/js/components/FormFields/FormFieldScribeEditor.js
+++ b/public/js/components/FormFields/FormFieldScribeEditor.js
@@ -24,7 +24,7 @@ export default class FormFieldsScribeEditor extends React.Component {
     wordCount: 0
   }
 
-  wordCount = (text) => text.trim().replace(/<(?:.|\n)*?>/gm, '').split(/\s+/).length;
+  wordCount = text => text.trim().replace(/<(?:.|\n)*?>/gm, '').split(/\s+/).filter(_ => _.length !== 0).length;
 
   renderWordCount = () => {
     const wordCount = this.wordCount(this.props.fieldValue);


### PR DESCRIPTION
If the field has no words, the word count is still set to 1 because there is an element with an empty string in the array produced by the word count. Filtering this out starts the word count from 0. 

@shaundillon 