### PR TITLE
Use code/prod presence JS scripts

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -66,7 +66,7 @@ object Config extends AwsInstanceTags {
   val previewReindexKinesisStreamName = getPropertyIfEnabled(kinesisEnabled, "aws.kinesis.reindex.preview")
 
   val presenceEnabled = getOptionalProperty("presence.enabled", config.getBoolean).getOrElse(true)
-  val presenceEndpointURL = getPropertyIfEnabled(presenceEnabled, "presence.endpoint")
+  val presenceDomain = getPropertyIfEnabled(presenceEnabled, "presence.domain")
 
   val capiPreviewUrl = config.getString("capi.previewUrl")
   val capiLiveUrl = config.getString("capi.liveUrl")

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -33,7 +33,7 @@ class App(val wsClient: WSClient, val atomWorkshopDB: AtomWorkshopDBAPI) extends
       embeddedMode = req.queryString.get("embeddedMode").map(_.head),
       atomEditorGutoolsDomain = Config.atomEditorGutoolsDomain,
       presenceEnabled = Config.presenceEnabled,
-      presenceEndpointURL = Config.presenceEndpointURL
+      presenceDomain = Config.presenceDomain
     )
 
     val jsFileName = "build/app.js"
@@ -41,7 +41,13 @@ class App(val wsClient: WSClient, val atomWorkshopDB: AtomWorkshopDBAPI) extends
     val jsLocation = sys.env.get("JS_ASSET_HOST").map(_ + jsFileName)
       .getOrElse(routes.Assets.versioned(jsFileName).toString)
 
-    Ok(views.html.index("Atom Workshop", jsLocation, clientConfig.asJson.noSpaces))
+    val presenceJsFile = if(Config.presenceEnabled) {
+      Some(s"https://${Config.presenceDomain}/client/1/lib.js")
+    } else {
+      None
+    }
+
+    Ok(views.html.index("Atom Workshop", jsLocation, presenceJsFile, clientConfig.asJson.noSpaces))
   }
 
   def getAtom(atomType: String, id: String, version: String) = AuthAction {

--- a/app/models/ClientConfig.scala
+++ b/app/models/ClientConfig.scala
@@ -20,7 +20,7 @@ case class ClientConfig(
                          embeddedMode: Option[String],
                          atomEditorGutoolsDomain: String,
                          presenceEnabled: Boolean,
-                         presenceEndpointURL: String
+                         presenceDomain: String
                        )
 
 object ClientConfig {

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,4 +1,4 @@
-@(title: String, jsLocation: String, clientConfigJson: String)
+@(title: String, jsLocation: String, presenceJsLocation: Option[String], clientConfigJson: String)
 <!DOCTYPE html>
 <html lang="en">
 
@@ -14,7 +14,11 @@
         <script type="application/json" id="config">
             @Html(clientConfigJson)
         </script>
-        <script src="https://presence.code.dev-gutools.co.uk/client/1/lib.js" type="application/javascript"></script>
+
+        @presenceJsLocation.map { presenceJs =>
+            <script src="@presenceJs" type="application/javascript"></script>
+        }
+
         <script src="@jsLocation" type="application/javascript"></script>
     </body>
 </html>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -25,7 +25,7 @@ const store = configureStore();
 const history = syncHistoryWithStore(browserHistory, store);
 
 const config = extractConfigFromPage();
-const presenceClient = config.presenceEnabled ? configurePresence(config.presenceEndpointURL, config.user) : {};
+const presenceClient = config.presenceEnabled ? configurePresence(config.domain, config.user) : {};
 
 setStore(store);
 

--- a/public/js/util/configurePresence.js
+++ b/public/js/util/configurePresence.js
@@ -1,3 +1,4 @@
-export default function configurePresence(endpoint, user) {
+export default function configurePresence(domain, user) {
+  const endpoint = `wss://${domain}/socket`;
   return window.presenceClient(endpoint, user);
 }


### PR DESCRIPTION
Inject the presence JS correctly based on stage, including nothing for DEV. It was previously using the CODE JS for everything.

Basically a port of https://github.com/guardian/media-atom-maker/pull/473