### PR TITLE
Remove title field from qanda editor

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/QAndAEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/QAndAEditor.js
@@ -18,14 +18,14 @@ export class QAndAEditor extends React.Component {
     return (
       <div className="form">
         <ManagedForm data={this.props.atom} updateData={this.props.onUpdate} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="qaEditor">
+          <ManagedField fieldLocation="data.qanda.item" name="Item">
+            <QAItem onFormErrorsUpdate={this.props.onFormErrorsUpdate} />
+          </ManagedField>
           <ManagedField fieldLocation="data.qanda.typeLabel" name="Label">
             <FormFieldTextInput/>
           </ManagedField>
           <ManagedField fieldLocation="data.qanda.eventImage" name="Event Image">
             <FormFieldImageSelect/>
-          </ManagedField>
-          <ManagedField fieldLocation="data.qanda.item" name="Item">
-            <QAItem onFormErrorsUpdate={this.props.onFormErrorsUpdate} />
           </ManagedField>
         </ManagedForm>
       </div>

--- a/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 import {ManagedForm, ManagedField} from '../../../ManagedEditor';
-import FormFieldTextInput from '../../../FormFields/FormFieldTextInput';
 import FormFieldTextArea from '../../../FormFields/FormFieldTextArea';
 
 export class QAItem extends React.Component {
@@ -29,10 +28,7 @@ export class QAItem extends React.Component {
     return (
       <div className="form__field">
         <ManagedForm data={value} updateData={this.updateItem} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="qaEditor">
-          <ManagedField fieldLocation="title" name="Title">
-            <FormFieldTextInput/>
-          </ManagedField>
-          <ManagedField fieldLocation="body" name="Body" isRequired={true}>
+          <ManagedField fieldLocation="body" name="Answer" isRequired={true}>
             <FormFieldTextArea/>
           </ManagedField>
         </ManagedForm>


### PR DESCRIPTION
The atom-level `title` field will be used (it is mandatory when creating a new atom).
Having this extra field is just confusing.
Also renamed "Body" label to "Answer"

![picture 10](https://user-images.githubusercontent.com/1513454/27579165-834c72c4-5b1e-11e7-80f2-cd1ee024b0f8.png)
