### PR TITLE
Support formatting in qanda answer

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/QAndAEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/QAndAEditor.js
@@ -23,7 +23,7 @@ export class QAndAEditor extends React.Component {
           <ManagedField fieldLocation="data.qanda.item" name="Item">
             <QAItem onFormErrorsUpdate={this.props.onFormErrorsUpdate} />
           </ManagedField>
-          <ManagedField fieldLocation="data.qanda.eventImage" name="Event Image">
+          <ManagedField fieldLocation="data.qanda.eventImage" name="Image">
             <FormFieldImageSelect gridUrl={this.props.config.gridUrl}/>
           </ManagedField>
         </ManagedForm>

--- a/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
 import {ManagedForm, ManagedField} from '../../../ManagedEditor';
-import FormFieldTextArea from '../../../FormFields/FormFieldTextArea';
+import FormFieldsScribeEditor from '../../../FormFields/FormFieldScribeEditor';
 
 export class QAItem extends React.Component {
   static propTypes = {
@@ -29,7 +29,7 @@ export class QAItem extends React.Component {
       <div className="form__field">
         <ManagedForm data={value} updateData={this.updateItem} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="qaEditor">
           <ManagedField fieldLocation="body" name="Answer" isRequired={true}>
-            <FormFieldTextArea/>
+            <FormFieldsScribeEditor showWordCount={true} suggestedLength={150} showToolbar={false}/>
           </ManagedField>
         </ManagedForm>
       </div>

--- a/public/js/components/FormFields/FormFieldScribeEditor.js
+++ b/public/js/components/FormFields/FormFieldScribeEditor.js
@@ -17,7 +17,8 @@ export default class FormFieldsScribeEditor extends React.Component {
     formRowClass: PropTypes.string,
     onUpdateField: PropTypes.func,
     showWordCount: PropTypes.bool,
-    suggestedLength: PropTypes.number
+    suggestedLength: PropTypes.number,
+    showToolbar: PropTypes.bool
   }
 
   state = {
@@ -42,7 +43,7 @@ export default class FormFieldsScribeEditor extends React.Component {
     return (
         <div className={(this.props.formRowClass || "form__row") + " scribe"}>
           {this.props.fieldLabel ? <label htmlFor={this.props.fieldName} className="form__label">{this.props.fieldLabel}</label> : false}
-          <ScribeEditor fieldName={this.props.fieldName} value={this.props.fieldValue} onUpdate={this.props.onUpdateField}/>
+          <ScribeEditor fieldName={this.props.fieldName} value={this.props.fieldValue} onUpdate={this.props.onUpdateField} showToolbar={this.props.showToolbar}/>
           {this.props.showWordCount ? this.renderWordCount() : false}
           <ShowErrors errors={this.props.fieldErrors}/>
         </div>
@@ -55,7 +56,8 @@ export class ScribeEditor extends React.Component {
   static propTypes = {
     fieldName: PropTypes.string,
     value: PropTypes.string,
-    onUpdate: PropTypes.func
+    onUpdate: PropTypes.func,
+    showToolbar: PropTypes.bool
   }
 
   componentDidMount() {
@@ -70,30 +72,32 @@ export class ScribeEditor extends React.Component {
 
   configureScribe() {
     // Create an instance of the Scribe toolbar
-    this.scribe.use(scribePluginToolbar(this.refs.toolbar));
+    if (this.props.showToolbar !== false) {
+      this.scribe.use(scribePluginToolbar(this.refs.toolbar));
 
-    // Configure Scribe plugins
-    this.scribe.use(scribePluginLinkPromptCommand());
-    this.scribe.use(scribeKeyboardShortcutsPlugin({
-      bold: function (event) { return event.metaKey && event.keyCode === 66; }, // b
-      italic: function (event) { return event.metaKey && event.keyCode === 73; }, // i
-      linkPrompt: function (event) { return event.metaKey && !event.shiftKey && event.keyCode === 75; }, // k
-      unlink: function (event) { return event.metaKey && event.shiftKey && event.keyCode === 75; } // shft + k
-    }));
+      // Configure Scribe plugins
+      this.scribe.use(scribePluginLinkPromptCommand());
+      this.scribe.use(scribeKeyboardShortcutsPlugin({
+        bold: function (event) { return event.metaKey && event.keyCode === 66; }, // b
+        italic: function (event) { return event.metaKey && event.keyCode === 73; }, // i
+        linkPrompt: function (event) { return event.metaKey && !event.shiftKey && event.keyCode === 75; }, // k
+        unlink: function (event) { return event.metaKey && event.shiftKey && event.keyCode === 75; } // shft + k
+      }));
 
-    this.scribe.use(scribePluginSanitizer({
-      tags: {
-        p: {},
-        i: {},
-        b: {},
-        a: {
-          href: true
-        },
-        ul: {},
-        ol: {},
-        li: {}
-      }
-    }));
+      this.scribe.use(scribePluginSanitizer({
+        tags: {
+          p: {},
+          i: {},
+          b: {},
+          a: {
+            href: true
+          },
+          ul: {},
+          ol: {},
+          li: {}
+        }
+      }));
+    }
 
   }
 
@@ -111,13 +115,15 @@ export class ScribeEditor extends React.Component {
   render() {
     return (
         <div>
-        <div ref="toolbar" className="scribe__toolbar">
-          <button type="button" data-command-name="bold" className="scribe__toolbar__item">Bold</button>
-          <button type="button" data-command-name="italic" className="scribe__toolbar__item">Italic</button>
-          <button type="button" data-command-name="linkPrompt" className="scribe__toolbar__item">Link</button>
-          <button type="button" data-command-name="unlink" className="scribe__toolbar__item">Unlink</button>
-        </div>
-        <div id={this.props.fieldName} ref="editor" className="scribe__editor"></div>
+          { this.props.showToolbar === false ? null :
+            <div ref="toolbar" className="scribe__toolbar">
+              <button type="button" data-command-name="bold" className="scribe__toolbar__item">Bold</button>
+              <button type="button" data-command-name="italic" className="scribe__toolbar__item">Italic</button>
+              <button type="button" data-command-name="linkPrompt" className="scribe__toolbar__item">Link</button>
+              <button type="button" data-command-name="unlink" className="scribe__toolbar__item">Unlink</button>
+            </div>
+          }
+          <div id={this.props.fieldName} ref="editor" className="scribe__editor"></div>
         </div>
   );
   }


### PR DESCRIPTION
This uses the existing `FormFieldsScribeEditor` component (which isn't currently being used). I've modified it to optionally hide the toolbar, since all we want is the ability to add `<p>` tags when the user creates a newline.
The suggested word count is 150 - it reports a warning if you go over, but still allows it.

(this will need a frontend change to use the body as html)

<img width="518" alt="picture 9" src="https://user-images.githubusercontent.com/1513454/28076805-ad49aaee-6657-11e7-99f1-9c758ca99754.png">
