### PR TITLE
Storyquestions closeDate field

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.0"
 scalaVersion := "2.11.8"
 
 lazy val awsVersion = "1.11.8"
-lazy val atomLibVersion = "1.1.0"
+lazy val atomLibVersion = "1.1.3"
 
 libraryDependencies ++= Seq(
   ws,

--- a/public/js/components/AtomEdit/CustomEditors/StoryQuestionsEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/StoryQuestionsEditor.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import FormFieldTagPicker from '../../FormFields/FormFieldTagPicker';
 import FormFieldTextInput from '../../FormFields/FormFieldTextInput';
+import FormFieldCheckbox from '../../FormFields/FormFieldCheckbox';
 import {StoryQuestionsQuestionSet} from './StoryQuestionFields/QuestionSet';
 import {ManagedField, ManagedForm} from '../../ManagedEditor';
 import {atomPropType} from '../../../constants/atomPropType';
@@ -12,12 +13,42 @@ export class StoryQuestionsEditor extends React.Component {
     atom: atomPropType.isRequired,
     onUpdate: PropTypes.func.isRequired,
     onFormErrorsUpdate: PropTypes.func
-  }
+  };
+
+  state = {
+    isClosed: this.props.atom.data.storyquestions.closeDate !== undefined && Date.now() >= this.props.atom.data.storyquestions.closeDate
+  };
+
+  //The model has a DateTime field, but for now the UI exposes this as a checkbox - closed or not
+  updateClose = (isClosed) => {
+    this.setState({isClosed: isClosed});
+
+    if (isClosed) {
+      const closed = Object.assign({}, this.props.atom, {
+        data: Object.assign({}, this.props.atom.data, {
+          storyquestions: Object.assign({}, this.props.atom.data.storyquestions, {
+            closeDate: Date.now()
+          })
+        })
+      });
+      this.props.onUpdate(closed);
+    } else {
+      const notClosed = Object.assign({}, this.props.atom, {
+        data: Object.assign({}, this.props.atom.data, {
+          storyquestions: Object.assign({}, this.props.atom.data.storyquestions, {
+            closeDate: undefined
+          })
+        })
+      });
+      this.props.onUpdate(notClosed);
+    }
+  };
 
   render () {
     return (
       <div className="form">
         <ManagedForm data={this.props.atom} updateData={this.props.onUpdate} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="storyquestionsEditor">
+          <FormFieldCheckbox fieldName="Closed" fieldValue={this.state.isClosed} onUpdateField={this.updateClose.bind(this)} />
           <ManagedField fieldLocation="data.storyquestions.title" name="Public Title" isRequired={true}>
             <FormFieldTextInput/>
           </ManagedField>

--- a/public/js/components/FormFields/FormFieldCheckbox.js
+++ b/public/js/components/FormFields/FormFieldCheckbox.js
@@ -13,7 +13,7 @@ export default class FormFieldCheckbox extends React.Component {
   }
 
   onUpdate = (e) => {
-    this.props.onUpdateField(e.target.value);
+    this.props.onUpdateField(e.target.checked);
   }
 
   render() {


### PR DESCRIPTION
Currently Editorial have to remove a storyquestions atom from all content when they want to stop displaying the atom.
Checking this box will tell the platforms not to render the atom.
The field is a dateTime, and checking this box sets it to the current time (UTC).

In future I'd like to make this a `Close` button in a sidebar on the right, using the 'custom actions' design being developed in this branch - https://github.com/guardian/atom-workshop/compare/rk-sq-notif.

But for now...
<img width="289" alt="picture 22" src="https://user-images.githubusercontent.com/1513454/28721239-8080bf68-73a7-11e7-93bd-83b9e2522209.png">
