### PR TITLE
Fix usage

### DIFF
--- a/public/js/actions/AtomActions/getAtomUsages.js
+++ b/public/js/actions/AtomActions/getAtomUsages.js
@@ -40,7 +40,7 @@ export function getAtomUsages(atomType, atomId) {
       Promise.all(res.map(getByPath))
         .then(capiResponse => {
           const usages = capiResponse.reduce((all, item) => {
-            all.push(item.response.content);
+            all.push(item);
             return all;
           }, []);
 

--- a/public/js/components/AtomStats/AtomStats.js
+++ b/public/js/components/AtomStats/AtomStats.js
@@ -24,29 +24,6 @@ class AtomStats extends React.Component {
     this.props.atomActions.getAtomUsages(this.props.routeParams.atomType, this.props.routeParams.id);
   }
 
-
-  renderAtomDetail = (name, value) => {
-    return (
-      <li key={name} className="details-list__item">
-        <span className="details-list__title">{name}:</span> {value}
-      </li>
-    );
-  }
-
-  renderAtomDetails = () => {
-    if(this.props.atom) {
-      const atomType = this.props.routeParams.atomType.toLowerCase();
-      return (
-        <ul className="details-list">
-          {
-            Object.keys(this.props.atom.data[atomType])
-            .map(key => this.renderAtomDetail(key, this.props.atom.data[atomType][key]))
-          }
-        </ul>
-      );
-    }
-  }
-
   renderAtomUsage = (usage, i) => {
     const composerLink = `${this.props.config.composerUrl}/content/${usage.fields.internalComposerCode}`;
     const viewerLink = `${this.props.config.viewerUrl}/preview/${usage.id}`;
@@ -85,9 +62,6 @@ class AtomStats extends React.Component {
     return (
       <div className="atom-editor">
         <h1 className="atom-editor__title">{this.props.atom ? this.props.atom.title : ''}</h1>
-        <div className="atom-editor__section">
-          {this.renderAtomDetails()}
-        </div>
         <h2>Usages</h2>
         <div className="atom-editor__section">
           {this.renderAtomUsages()}

--- a/public/js/services/capi.js
+++ b/public/js/services/capi.js
@@ -64,6 +64,6 @@ export const getByPath = (path) => {
   )
   .then((res) => res.json())
   .then((json) => {
-    return Promise.resolve(json.response.results);
+    return Promise.resolve(json.response.content);
   });
 };


### PR DESCRIPTION
1. Process the capi item response correctly
2. Remove `renderAtomDetails` as it breaks (with a horribly non-specific error). I'm not sure we need more details besides the title of the atom. If we do then this can be added later.

It looks like this:
![picture 23](https://user-images.githubusercontent.com/1513454/28961608-d17400e4-78fa-11e7-9ac0-657e8f480020.png)
