### PR TITLE
Suggested content

### DIFF
--- a/public/js/actions/AtomActions/getSuggestedContent.js
+++ b/public/js/actions/AtomActions/getSuggestedContent.js
@@ -1,0 +1,72 @@
+import {getContentByTags} from '../../services/capi';
+import {fetchTargetsForAtomPath} from '../../services/TargetingApi';
+import {logError} from '../../util/logger';
+
+
+function requestSuggestedContent(atomType, id) {
+  return {
+    type:       'SUGGESTED_CONTENT_GET_REQUEST',
+    atomType:   atomType,
+    id:         id,
+    receivedAt: Date.now()
+  };
+}
+
+function receiveSuggestedContent(suggestedContent) {
+  return {
+    type:       'SUGGESTED_CONTENT_GET_RECEIVE',
+    suggestedContent: suggestedContent,
+    receivedAt: Date.now()
+  };
+}
+
+function errorReceivingSuggestedContent(error) {
+  logError(error);
+  return {
+    type:       'SHOW_ERROR',
+    message:    'Could not get atom usages',
+    error:      error,
+    receivedAt: Date.now()
+  };
+}
+
+/**
+ * Gets tags from Target api.
+ * Queries capi for content with those tags, filtering out
+ * any content which already have this atom.
+ */
+export function getSuggestedContent(atomId, atomType) {
+  const path = `/atom/${atomType.toLowerCase()}/${atomId}`;
+  const pluralType = `${atomType}s`;
+
+  return dispatch => {
+    dispatch(requestSuggestedContent(atomType, atomId));
+    return fetchTargetsForAtomPath(path)
+      .then((targets) => {
+        return targets.map((target) => {
+          return target.tagPaths;
+        });
+      })
+      .then(tags => getContentByTags(tags, pluralType))
+      .then(content => {
+        //Exclude any content with this atom
+        const suggested = content.filter(c => {
+          if (c.atoms && c.atoms[pluralType]) {
+            const atomIdx = c.atoms[pluralType].find(a => {
+              return a.id === atomId;
+            });
+            return atomIdx === -1;
+          } else {
+            return true;
+          }
+        });
+
+        suggested.sort((first, second) => new Date(second.fields.creationDate) - new Date(first.fields.creationDate));
+
+        dispatch(receiveSuggestedContent(suggested));
+      })
+      .catch(error => {
+        dispatch(errorReceivingSuggestedContent(error));
+      });
+  };
+}

--- a/public/js/components/AtomStats/AtomStats.js
+++ b/public/js/components/AtomStats/AtomStats.js
@@ -11,9 +11,11 @@ class AtomStats extends React.Component {
     }).isRequired,
     atomActions: PropTypes.shape({
       getAtomUsages: PropTypes.func.isRequired,
+      getSuggestedContent: PropTypes.func.isRequired
     }).isRequired,
     atom: atomPropType,
     atomUsages: PropTypes.array,
+    suggestedContent: PropTypes.array,
     config: PropTypes.shape({
       composerUrl: PropTypes.string.isRequired,
       viewerUrl: PropTypes.string.isRequired
@@ -22,38 +24,61 @@ class AtomStats extends React.Component {
 
   componentWillMount() {
     this.props.atomActions.getAtomUsages(this.props.routeParams.atomType, this.props.routeParams.id);
+    this.props.atomActions.getSuggestedContent(this.props.routeParams.id, this.props.routeParams.atomType);
   }
 
-  renderAtomUsage = (usage, i) => {
-    const composerLink = `${this.props.config.composerUrl}/content/${usage.fields.internalComposerCode}`;
-    const viewerLink = `${this.props.config.viewerUrl}/preview/${usage.id}`;
-    const websiteLink = `https://www.theguardian.com/${usage.id}`;
+  renderContent = (usage, i) => {
+    const headline = usage.fields.headline;
+    if (headline) {
+      const composerLink = `${this.props.config.composerUrl}/content/${usage.fields.internalComposerCode}`;
+      const viewerLink = `${this.props.config.viewerUrl}/preview/${usage.id}`;
+      const websiteLink = `https://www.theguardian.com/${usage.id}`;
 
-    return (
-      <li className="usages-list__item" key={`usage-${i}`}>
-        <p className="usages-list__item__name">{usage.fields.headline}</p>
-        <div className="usages-list__links">
-          <p className="usages-list__item__date">Created: {distanceInWordsToNow(usage.fields.creationDate, {addSuffix: true})}
-          <a className="usages-list__link" href={websiteLink} title="Open on theguardian.com" target="_blank">
-            <FrontendIcon />
-          </a>
-          <a className="usages-list__link" href={composerLink} title="Open in Composer" target="_blank">
-            <ComposerIcon />
-          </a>
-          <a className="usages-list__link" href={viewerLink} title="Open in Viewer" target="_blank">
-            <ViewerIcon />
-          </a></p>
-        </div>
-      </li>
-    );
+      return (
+        <li className="usages-list__item" key={`usage-${i}`}>
+          <p className="usages-list__item__name">{headline}</p>
+          <div className="usages-list__links">
+            <p className="usages-list__item__date">
+              Created: {distanceInWordsToNow(usage.fields.creationDate, {addSuffix: true})}
+              <a className="usages-list__link" href={websiteLink} title="Open on theguardian.com" target="_blank">
+                <FrontendIcon />
+              </a>
+              <a className="usages-list__link" href={composerLink} title="Open in Composer" target="_blank">
+                <ComposerIcon />
+              </a>
+              <a className="usages-list__link" href={viewerLink} title="Open in Viewer" target="_blank">
+                <ViewerIcon />
+              </a></p>
+          </div>
+        </li>
+      );
+    }
   }
 
   renderAtomUsages = () => {
-    if(this.props.atomUsages) {
+    if (this.props.atomUsages && this.props.atomUsages.length > 0) {
+        return (
+          <ul className="usages-list">
+            {this.props.atomUsages.map((usage, i) => this.renderContent(usage, i))}
+          </ul>
+        );
+    } else {
+      return (
+        <div>This atom is not currently used in any content.</div>
+      );
+    }
+  }
+
+  renderSuggestedContent = () => {
+    if (this.props.suggestedContent && this.props.suggestedContent.length > 0) {
       return (
         <ul className="usages-list">
-          {this.props.atomUsages.map((usage, i) => this.renderAtomUsage(usage, i))}
+          {this.props.suggestedContent.map((usage, i) => this.renderContent(usage, i))}
         </ul>
+      );
+    } else {
+      return (
+        <div>No suggested content for the last 7 days.</div>
       );
     }
   }
@@ -66,6 +91,10 @@ class AtomStats extends React.Component {
         <div className="atom-editor__section">
           {this.renderAtomUsages()}
         </div>
+        <h2>Not yet included</h2>
+        <div className="atom-editor__section">
+          {this.renderSuggestedContent()}
+        </div>
       </div>
     );
   }
@@ -76,18 +105,20 @@ class AtomStats extends React.Component {
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as getAtomUsagesActions from '../../actions/AtomActions/getAtomUsages.js';
+import * as getSuggestedContentActions from '../../actions/AtomActions/getSuggestedContent.js';
 
 function mapStateToProps(state) {
   return {
     atom: state.atom,
     atomUsages: state.atomUsages,
+    suggestedContent: state.suggestedContent,
     config: state.config
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
-    atomActions: bindActionCreators(Object.assign({}, getAtomUsagesActions), dispatch)
+    atomActions: bindActionCreators(Object.assign({}, getAtomUsagesActions, getSuggestedContentActions), dispatch)
   };
 }
 

--- a/public/js/reducers/atomUsagesReducer.js
+++ b/public/js/reducers/atomUsagesReducer.js
@@ -1,8 +1,7 @@
 export default function atomUsages(state = null, action) {
     switch (action.type) {
-
         case 'ATOM_USAGES_GET_RECEIVE':
-            return action.atomUsages || false;
+            return action.atomUsages || null;
 
         default:
             return state;

--- a/public/js/reducers/rootReducer.js
+++ b/public/js/reducers/rootReducer.js
@@ -9,6 +9,7 @@ import atom from '../reducers/atomReducer';
 import saveState from '../reducers/saveStateReducer';
 import atomList from '../reducers/atomListReducer';
 import atomUsages from '../reducers/atomUsagesReducer';
+import suggestedContent from '../reducers/suggestedContentReducer';
 import externalAtom from '../reducers/externalAtomReducer';
 import queryParams from '../reducers/queryParamsReducer';
 import {routerReducer} from 'react-router-redux';
@@ -23,6 +24,7 @@ export const rootReducer = combineReducers({
   saveState,
   atomList,
   atomUsages,
+  suggestedContent,
   externalAtom,
   queryParams,
   routing: routerReducer

--- a/public/js/reducers/suggestedContentReducer.js
+++ b/public/js/reducers/suggestedContentReducer.js
@@ -1,0 +1,10 @@
+export default function suggestedContent(state = null, action) {
+  switch (action.type) {
+
+    case 'SUGGESTED_CONTENT_GET_RECEIVE':
+      return action.suggestedContent || null;
+
+    default:
+      return state;
+  }
+}

--- a/public/js/services/capi.js
+++ b/public/js/services/capi.js
@@ -67,3 +67,18 @@ export const getByPath = (path) => {
     return Promise.resolve(json.response.content);
   });
 };
+
+export const getContentByTags = (tags, atomType) => {
+  const date = new Date(new Date().setDate(new Date().getDate()-7));
+  return pandaFetch(
+    `/support/previewCapi/search?tag=${tags.join(',')}&show-atoms=${atomType}&show-fields=all&from-date=${date.toISOString()}`,
+    {
+      method: 'get',
+      credentials: 'same-origin'
+    }
+  )
+  .then((res) => res.json())
+  .then((json) => {
+    return Promise.resolve(json.response.results);
+  });
+};


### PR DESCRIPTION
In the `stats` page we currently only display a list of content that uses the atom.
This change adds a list of suggested content. This list is based on any target tags. Only content from the last 7 days is included.

E.g. before adding to content:
<img width="437" alt="picture 7" src="https://user-images.githubusercontent.com/1513454/29067791-dee0aeb0-7c2b-11e7-9bf3-6003f2c19cc1.png">
And after:
<img width="450" alt="picture 8" src="https://user-images.githubusercontent.com/1513454/29067792-df20df94-7c2b-11e7-8bdc-5dbf60a40d29.png">
