### PR TITLE
Link to 'stats' page from edit page

### DIFF
--- a/public/js/components/AtomEmbed/AtomEmbed.js
+++ b/public/js/components/AtomEmbed/AtomEmbed.js
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react';
 import {atomPropType} from '../../constants/atomPropType.js';
 import copy from 'copy-to-clipboard';
+import {Link} from 'react-router';
 
 import CurrentTargets from './CurrentTargets';
 
@@ -65,6 +66,12 @@ class AtomEmbed extends React.Component {
             <div className="form__row">
               <CurrentTargets atom={this.props.atom} />
             </div>
+          </div>
+          <div className="form__row">
+            <Link to={`/atoms/${this.props.atom.atomType}/${this.props.atom.id}/stats`}
+              className="atom-list__link">
+              Where can I embed this atom?
+            </Link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
A link at the bottom of the sidebar.
This page displays current and suggested usages based on the targets.

![picture 13](https://user-images.githubusercontent.com/1513454/29216598-142b0f20-7ea7-11e7-9c0b-994f343d6181.png)
