### PR TITLE
Lowercase atomtype for capi queries

### DIFF
--- a/public/js/services/capi.js
+++ b/public/js/services/capi.js
@@ -28,7 +28,7 @@ export const searchAtoms = (query) => {
 
 export const fetchCapiAtom = (atomType, atomId) => {
   return pandaFetch(
-    `/support/previewCapi/atom/${atomType}/${atomId}`,
+    `/support/previewCapi/atom/${atomType.toLowerCase()}/${atomId}`,
     {
       method: 'get',
       credentials: 'same-origin'
@@ -42,7 +42,7 @@ export const fetchCapiAtom = (atomType, atomId) => {
 
 export const fetchAtomUsages = (atomType, atomId) => {
   return pandaFetch(
-    `/support/previewCapi/atom/${atomType}/${atomId}/usage`,
+    `/support/previewCapi/atom/${atomType.toLowerCase()}/${atomId}/usage`,
     {
       method: 'get',
       credentials: 'same-origin'


### PR DESCRIPTION
This currently causes requests from the stats page to sometimes fail