### PR TITLE
Improve add & delete buttons in atom editor

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
@@ -26,7 +26,7 @@ export class GuideItem extends React.Component {
       body: ""
     };
     return (
-      <div className="form__field">
+      <div className="form__field form__field--nested">
         <ManagedForm data={value} updateData={this.updateItem} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="guideEditor">
           <ManagedField fieldLocation="title" name="Title">
             <FormFieldTextInput/>

--- a/public/js/components/AtomEdit/CustomEditors/ProfileFields/ProfileItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/ProfileFields/ProfileItem.js
@@ -26,7 +26,7 @@ export class ProfileItem extends React.Component {
       body: ""
     };
     return (
-      <div className="form__field">
+      <div className="form__field form__field--nested">
         <ManagedForm data={value} updateData={this.updateItem} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="profileEditor">
           <ManagedField fieldLocation="title" name="Title">
             <FormFieldTextInput/>

--- a/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Question.js
+++ b/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Question.js
@@ -26,7 +26,7 @@ export class StoryQuestionsQuestion extends React.Component {
 
   render () {
     return (
-      <div className="form__field">
+      <div className="form__field form__field--nested">
         <ManagedForm data={this.props.fieldValue} updateData={this.updateQuestion} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="storyquestionsEditor">
           <ManagedField fieldLocation="questionText" name="Question" isRequired={true}>
             <FormFieldTextInput />

--- a/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/QuestionSet.js
+++ b/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/QuestionSet.js
@@ -36,7 +36,7 @@ export class StoryQuestionsQuestionSet extends React.Component {
       questions: []
     };
     return (
-      <div className="form__field">
+      <div className="form__field form__field--questions">
         <ManagedForm data={value} updateData={this.updateQuestionSet} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="storyquestionsEditor">
           <ManagedField fieldLocation="questions" name="Questions" isRequired={true}>
             <FormFieldArrayWrapper>

--- a/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
@@ -29,7 +29,7 @@ export class TimelineItem extends React.Component {
       body: ""
     };
     return (
-      <div className="form__field">
+      <div className="form__field form__field--nested">
         <ManagedForm data={value} updateData={this.updateItem} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="timelineEditor">
         <ManagedField fieldLocation="date" name="Date" isRequired={true}>
           <FormFieldDateInput isOutsideRange={() => false}/>

--- a/public/js/components/FormFields/FormFieldArrayWrapper.js
+++ b/public/js/components/FormFields/FormFieldArrayWrapper.js
@@ -19,8 +19,8 @@ export default class FormFieldArrayWrapper extends React.Component {
   }
 
   onAddClick = () => {
-    const exisitingValues = this.props.fieldValue || [];
-    this.props.onUpdateField(exisitingValues.concat([undefined]));
+    const existingValues = this.props.fieldValue || [];
+    this.props.onUpdateField(existingValues.concat([undefined]));
   }
 
   renderValue(value, i) {
@@ -53,10 +53,10 @@ export default class FormFieldArrayWrapper extends React.Component {
     });
 
     return (
-      <div className={this.props.fieldClass ? this.props.fieldClass : 'form__group'}>
+      <div className={this.props.fieldClass ? this.props.fieldClass : 'form__group form__field'}>
         {this.props.numbered ? <span className="form__field-number">{`${i + 1}. `}</span> : false }
         {hydratedChildren}
-        <button className="btn form__field-btn" type="button" onClick={removeFn.bind(this, i)}>Delete</button>
+        <button className="btn form__field-btn btn--red" type="button" onClick={removeFn.bind(this, i)}>Delete</button>
       </div>
     );
   }
@@ -69,9 +69,9 @@ export default class FormFieldArrayWrapper extends React.Component {
       <div className={this.props.nested ? 'form__row form__row--nested' : 'form__row'}>
         <div className="form__btn-heading">
           <span className="form__label">{this.props.fieldLabel}</span>
-          <button className="form__btn-heading__btn" type="button" onClick={this.onAddClick}>Add</button>
-        </div>
-        {values.map((value, i) => this.renderValue(value, i))}
+       </div>
+          {values.map((value, i) => this.renderValue(value, i))}
+        <button className="form__btn-heading__btn form__btn-heading__add" type="button" onClick={this.onAddClick}>Add</button>
       </div>
     );
   }

--- a/public/js/components/FormFields/FormFieldCheckbox.js
+++ b/public/js/components/FormFields/FormFieldCheckbox.js
@@ -18,7 +18,7 @@ export default class FormFieldCheckbox extends React.Component {
 
   render() {
     return (
-      <div className="form__group">
+      <div className="form__ group form__group--checkbox">
         {this.props.fieldLabel ? <label className="form__label" htmlFor={this.props.fieldName}>{this.props.fieldLabel}</label> : false}
         <input className="form__checkbox" type="checkbox" checked={this.props.fieldValue} name={this.props.fieldName} value={this.props.fieldValue} onChange={this.onUpdate} />
         {!this.props.fieldLabel ? <span className="form__label form__label--checkbox">{this.props.fieldName}</span> : false}

--- a/public/js/components/FormFields/FormFieldRadioButtons.js
+++ b/public/js/components/FormFields/FormFieldRadioButtons.js
@@ -20,7 +20,7 @@ export default class FormFieldRadioButtons extends React.Component {
 
   renderButton(value, i) {
     return (
-      <div key={i} className="form__group form__group--radio">
+      <div key={i} className="form__group--radio">
         <input className="form__radio-btn" type="radio" name={this.props.fieldName} value={value} checked={this.props.fieldValue === value ? 'checked' : false} onChange={this.onUpdate} />
         <span className="form__label form__label--radio">{value}</span>
       </div>

--- a/public/js/components/FormFields/__snapshots__/FormFieldCheckbox.spec.js.snap
+++ b/public/js/components/FormFields/__snapshots__/FormFieldCheckbox.spec.js.snap
@@ -1,6 +1,6 @@
 exports[`test Should render 1`] = `
 <div
-  className="form__group">
+  className="form__ group form__group--checkbox">
   <label
     className="form__label"
     htmlFor="test">

--- a/public/js/components/FormFields/__snapshots__/FormFieldCheckboxGroup.spec.js.snap
+++ b/public/js/components/FormFields/__snapshots__/FormFieldCheckboxGroup.spec.js.snap
@@ -7,7 +7,7 @@ exports[`test Should render 1`] = `
     test
   </label>
   <div
-    className="form__group">
+    className="form__ group form__group--checkbox">
     <input
       checked={true}
       className="form__checkbox"
@@ -21,7 +21,7 @@ exports[`test Should render 1`] = `
     </span>
   </div>
   <div
-    className="form__group">
+    className="form__ group form__group--checkbox">
     <input
       checked={true}
       className="form__checkbox"
@@ -35,7 +35,7 @@ exports[`test Should render 1`] = `
     </span>
   </div>
   <div
-    className="form__group">
+    className="form__ group form__group--checkbox">
     <input
       checked={false}
       className="form__checkbox"

--- a/public/js/components/FormFields/__snapshots__/FormFieldRadioButtons.spec.js.snap
+++ b/public/js/components/FormFields/__snapshots__/FormFieldRadioButtons.spec.js.snap
@@ -7,7 +7,7 @@ exports[`test Should render 1`] = `
     test
   </label>
   <div
-    className="form__group form__group--radio">
+    className="form__group--radio">
     <input
       checked={false}
       className="form__radio-btn"
@@ -21,7 +21,7 @@ exports[`test Should render 1`] = `
     </span>
   </div>
   <div
-    className="form__group form__group--radio">
+    className="form__group--radio">
     <input
       checked={false}
       className="form__radio-btn"

--- a/public/styles/components/_atom-editor.scss
+++ b/public/styles/components/_atom-editor.scss
@@ -18,7 +18,7 @@
   }
 
   &__form {
-    margin-top: 20px;
+    margin: 20px 40px;
     padding-top: 20px;
     border-top: 1px solid $color300Grey;
   }

--- a/public/styles/components/_forms.scss
+++ b/public/styles/components/_forms.scss
@@ -37,8 +37,8 @@
 .form__field {
   background-color: $cWhite;
   padding: 11px;
-  border: 1px solid $color300Grey;
   width: 100%;
+  border: 1px solid $color300Grey;
 
   &:not(:last-child) {
     margin-bottom: 10px;
@@ -63,12 +63,22 @@
   &--error, &--error:focus {
     border-color: $cRedB5;
   }
+
+  &--questions {
+    border: 1px solid $color300Grey;
+    margin-bottom: 20px;
+  }
+
+  &--nested {
+    border: none;
+  }
 }
 
 .form__field--multiselect {
   $multiSelectBtnWidth: 45px;
   position: relative;
   padding-right: $multiSelectBtnWidth + 10px;
+  border: 1px solid $color300Grey;
 
   &__btn {
     width: $multiSelectBtnWidth;
@@ -135,7 +145,12 @@
 }
 
 .form__group {
-  margin-bottom: 5px;
+  margin-bottom: 10px;
+  border: 1px solid $color300Grey;
+
+  &--checkbox {
+    border: none;
+  }
 
   &--flex {
     display: flex;
@@ -227,6 +242,12 @@
       background: $brandColor;
     }
   }
+
+  &__add {
+    display: table;
+    margin-left: auto;
+  }
+
 }
 
 // Flex container for side by side fields and other adventures


### PR DESCRIPTION
This is probably some real ~nasty~ _hacky_ CSS so comments v welcome!! Given this makes changes to shared components I've included screenshots so you can see effect across atom editors.

Screenshots of new styling:

**Story Questions:**

![screen shot 2017-08-25 at 15 33 36](https://user-images.githubusercontent.com/14946184/29718462-ccdb3b54-89aa-11e7-8659-abafece9117c.png)

**Quick Guide:**

![screen shot 2017-08-25 at 15 31 38](https://user-images.githubusercontent.com/14946184/29718441-b98a193a-89aa-11e7-8526-bd0676229938.png)

**CTA:**

![screen shot 2017-08-25 at 15 34 15](https://user-images.githubusercontent.com/14946184/29718497-e572b728-89aa-11e7-965d-396d331bfa0a.png)

**Recipe:**

![screen shot 2017-08-25 at 15 34 53](https://user-images.githubusercontent.com/14946184/29718528-f89a386c-89aa-11e7-86dc-07bab090a242.png)

**Profile:**

![screen shot 2017-08-25 at 15 35 19](https://user-images.githubusercontent.com/14946184/29718545-06aadaf6-89ab-11e7-8474-13b08f06da75.png)

**Timeline:**

![screen shot 2017-08-25 at 15 35 45](https://user-images.githubusercontent.com/14946184/29718563-18b1491a-89ab-11e7-9120-177f8ca8dce4.png)
