### PR TITLE
Create Exact Target email lists for storyquestions atoms

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -8,21 +8,22 @@ import play.api.ApplicationLoader.Context
 import play.api._
 import play.api.libs.ws.ahc.AhcWSComponents
 import router.Routes
+import services.NotificationLists
 
 class AppComponents(context: Context)
   extends BuiltInComponentsFromContext(context) with AhcWSComponents {
 
   val logger = new LogConfig
 
-  lazy val router = new Routes(httpErrorHandler, appController, healthcheckController, loginController, assets, supportController, reindex)
+  lazy val router = new Routes(httpErrorHandler, appController, healthcheckController, loginController, assets, supportController, reindex, atomActionsController)
   lazy val assets = new controllers.Assets(httpErrorHandler)
   lazy val appController = new controllers.App(wsClient, atomWorkshopDB)
   lazy val loginController = new controllers.Login(wsClient)
   lazy val healthcheckController = new controllers.Healthcheck()
   lazy val supportController = new controllers.Support(wsClient)
+  lazy val atomActionsController = new controllers.AtomActions(wsClient, atomWorkshopDB)
 
   lazy val reindex = new ReindexController(previewDataStore, publishedDataStore, reindexPreview, reindexPublished, Configuration(config), actorSystem)
 
   lazy val atomWorkshopDB = new AtomWorkshopDB()
 }
-

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -4,7 +4,8 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
 import com.amazonaws.services.kinesis.AmazonKinesisClient
-import com.gu.cm.{Configuration => ConfigurationMagic, Mode}
+import com.gu.cm.{Mode, Configuration => ConfigurationMagic}
+import com.gu.exact_target_lists.ExactTargetConfig
 import services.AwsInstanceTags
 
 object Config extends AwsInstanceTags {
@@ -80,4 +81,13 @@ object Config extends AwsInstanceTags {
     awsCredentialsProvider,
     null
   )
+
+  val exactTargetConfig: Option[ExactTargetConfig] =
+    for {
+      username <- getOptionalProperty("exactTarget.username", config.getString)
+      password <- getOptionalProperty("exactTarget.password", config.getString)
+      folderId <- getOptionalProperty("exactTarget.folderId", config.getInt)
+      endpoint <- getOptionalProperty("exactTarget.endpoint", config.getString)
+      clientId <- getOptionalProperty("exactTarget.clientId", config.getString)
+    } yield ExactTargetConfig(username, password, folderId, endpoint, clientId)
 }

--- a/app/controllers/AtomActions.scala
+++ b/app/controllers/AtomActions.scala
@@ -1,0 +1,58 @@
+package controllers
+
+import cats.syntax.either._
+import com.gu.contentatom.thrift.{Atom, EventType}
+import db.AtomDataStores._
+import db.AtomWorkshopDBAPI
+import models._
+import play.api.libs.ws.WSClient
+import play.api.mvc.Controller
+import services.AtomPublishers._
+import services.NotificationLists
+import util.AtomLogic._
+import util.AtomUpdateOperations._
+import io.circe._
+import com.gu.fezziwig.CirceScroogeMacros._
+import com.gu.pandomainauth.action.UserRequest
+
+class AtomActions(val wsClient: WSClient, val atomWorkshopDB: AtomWorkshopDBAPI) extends Controller with PanDomainAuthActions {
+
+  def createNotificationList(atomType: String, id: String) = AuthAction { req =>
+    APIResponse {
+      for {
+        currentDraftAtom <- getCurrentDraftAtom(atomType, id)
+        postHookAtom <- NotificationLists.createNotificationList(currentDraftAtom)
+        updatedAtom <- publishUpdatedAtom(postHookAtom, req)
+      } yield updatedAtom
+    }
+  }
+
+  def deleteNotificationList(atomType: String, id: String) = AuthAction { req =>
+    APIResponse {
+      for {
+        currentDraftAtom <- getCurrentDraftAtom(atomType, id)
+        postHookAtom <- NotificationLists.deleteNotificationList(currentDraftAtom)
+        updatedAtom <- publishUpdatedAtom(postHookAtom, req)
+      } yield updatedAtom
+    }
+  }
+
+  private def getCurrentDraftAtom(atomType: String, id: String): Either[AtomAPIError, Atom] = for {
+    atomType <- validateAtomType(atomType)
+    currentDraftAtom <- atomWorkshopDB.getAtom(previewDataStore, atomType, id)
+  } yield currentDraftAtom
+
+  private def publishUpdatedAtom(atom: Atom, req: UserRequest[_]): Either[AtomAPIError, Atom] = {
+    atomWorkshopDB.publishAtom(publishedDataStore, req.user, updateTopLevelFields(atom, req.user, publish=true)).flatMap { updatedAtom =>
+      val previewUpdateResult = atomWorkshopDB.updateAtom(previewDataStore, updatedAtom)
+      val liveKinesisResult = sendKinesisEvent(updatedAtom, liveAtomPublisher, EventType.Update)
+      val previewKinesisResult = sendKinesisEvent(updatedAtom, previewAtomPublisher, EventType.Update)
+
+      for {
+        _ <- previewUpdateResult
+        _ <- liveKinesisResult
+        _ <- previewKinesisResult
+      } yield updatedAtom
+    }
+  }
+}

--- a/app/models/Errors.scala
+++ b/app/models/Errors.scala
@@ -10,6 +10,7 @@ case class AmazonDynamoError(message: String) extends AtomAPIError(s"Error throw
 case class AtomWorkshopDynamoDatastoreError(message: String) extends AtomAPIError(message)
 case class AtomJsonParsingError(message: String) extends AtomAPIError(s"Failed to parse Json string with error: $message")
 case class AtomThriftDeserialisingError(message: String) extends AtomAPIError(s"Failed to deserialise JSON into thrift with error: $message")
+case class NotificationListsError(message: String) extends AtomAPIError(s"Notification lists error for atom: $message")
 case object UnexpectedExceptionError extends AtomAPIError("Atom workshop hit an exception it didn't expect. Please try again!")
 case object BodyRequiredForUpdateError extends AtomAPIError("You must provide a JSON representation of the the new version of the atom you wish to update in the body of your request")
 case object KinesisPublishingFailed extends AtomAPIError("Failed to publish to Content API via kinesis")

--- a/app/services/NotificationLists.scala
+++ b/app/services/NotificationLists.scala
@@ -1,0 +1,52 @@
+package services
+
+import cats.implicits._
+import com.gu.contentatom.thrift.{Atom, AtomData, EmailProvider, NotificationProviders}
+import com.gu.exact_target_lists.ExactTargetLists
+import config.Config
+import models.{AtomAPIError, NotificationListsError}
+
+object NotificationLists {
+
+  private val exactTargetLists: Either[NotificationListsError, ExactTargetLists] = {
+    Config.exactTargetConfig match {
+      case Some(config) => Either.right(new ExactTargetLists(config))
+      case None => Either.left(NotificationListsError(s"Exact Target is not configured to run."))
+    }
+  }
+
+  def createNotificationList(atom: Atom): Either[AtomAPIError, Atom] = atom.data match {
+    case AtomData.Storyquestions(data) if data.notifications.isEmpty =>
+      createNotificationList(data.title, atom.id).map { listId =>
+        val updatedData = data.copy(notifications = Some(NotificationProviders(email = Some(EmailProvider(listId = listId.toString)))))
+        atom.copy(data = AtomData.Storyquestions(updatedData))
+      }
+    case _ => Either.right(atom)
+  }
+
+  def deleteNotificationList(atom: Atom): Either[AtomAPIError, Atom] = atom.data match {
+    case AtomData.Storyquestions(data) if data.notifications.isDefined =>
+      val result = for {
+        notifications <- data.notifications
+        email <- notifications.email
+        listId = email.listId
+      } yield {
+        val updatedData = data.copy(notifications = None)
+        deleteNotificationList(listId.toInt).map { _ =>
+          atom.copy(data = AtomData.Storyquestions(updatedData))
+        }
+      }
+      result.getOrElse(Either.right(atom))
+
+    case _ => Either.right(atom)
+  }
+
+  private def createNotificationList(title: String, id: String): Either[AtomAPIError, Int] =
+    exactTargetLists.flatMap(_.createExactTargetList(title, Some(id))
+      .left.map(e => NotificationListsError(e.message)))
+
+
+  private def deleteNotificationList(listId: Int): Either[AtomAPIError, Int] =
+    exactTargetLists.flatMap(_.deleteExactTargetList(listId)
+      .left.map(e => NotificationListsError(e.message)))
+}

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "com.gu"                   %% "pan-domain-auth-play_2-5"    % "0.4.1",
   "io.circe"                 %% "circe-parser"                % "0.7.0",
   "net.logstash.logback"     %  "logstash-logback-encoder"    % "4.2",
-  "com.chuusai"              %% "shapeless"                   % "2.3.2"
+  "com.gu"                   %% "exact-target-lists"          % "0.1"
 )
 
 resolvers ++= Seq(

--- a/conf/routes
+++ b/conf/routes
@@ -38,3 +38,7 @@ POST    /reindex-preview                         com.gu.atom.play.ReindexControl
 POST    /reindex-publish                         com.gu.atom.play.ReindexController.newPublishedReindexJob()
 GET     /reindex-preview                         com.gu.atom.play.ReindexController.previewReindexJobStatus()
 GET     /reindex-publish                         com.gu.atom.play.ReindexController.publishedReindexJobStatus()
+
+# Custom atom actions
+POST    /api/live/:atomType/:id/custom/notifications controllers.AtomActions.createNotificationList(atomType: String, id: String)
+DELETE  /api/live/:atomType/:id/custom/notifications controllers.AtomActions.deleteNotificationList(atomType: String, id: String)

--- a/public/js/actions/AtomActions/createNotificationList.js
+++ b/public/js/actions/AtomActions/createNotificationList.js
@@ -1,0 +1,40 @@
+import AtomsApi from '../../services/AtomsApi';
+import {logError} from '../../util/logger';
+
+function requestAtomCreateNotificationList(atom) {
+  return {
+    type:       'ATOM_CREATE_NOTIFICATION_REQUEST',
+    atom,
+    receivedAt: Date.now()
+  };
+}
+
+function receiveAtomCreateNotificationList(atom) {
+  return {
+    type:       'ATOM_CREATE_NOTIFICATION_RECEIVE',
+    atom,
+    receivedAt: Date.now()
+  };
+}
+
+function errorCreatingNotificationList(error) {
+  logError(error);
+  return {
+    type:       'SHOW_ERROR',
+    message:    'Could not create notification list',
+    error,
+    receivedAt: Date.now()
+  };
+}
+
+export function createNotificationList(atom) {
+  return dispatch => {
+    dispatch(requestAtomCreateNotificationList(atom));
+    return AtomsApi.createNotificationList(atom)
+        .then(res => res.json())
+        .then(atom => {
+          dispatch(receiveAtomCreateNotificationList(atom));
+        })
+        .catch(error => dispatch(errorCreatingNotificationList(error)));
+  };
+}

--- a/public/js/actions/AtomActions/deleteNotificationList.js
+++ b/public/js/actions/AtomActions/deleteNotificationList.js
@@ -1,0 +1,40 @@
+import AtomsApi from '../../services/AtomsApi';
+import {logError} from '../../util/logger';
+
+function requestAtomDeleteNotificationList(atom) {
+  return {
+    type:       'ATOM_DELETE_NOTIFICATION_REQUEST',
+    atom,
+    receivedAt: Date.now()
+  };
+}
+
+function receiveAtomDeleteNotificationList(atom) {
+  return {
+    type:       'ATOM_DELETE_NOTIFICATION_RECEIVE',
+    atom,
+    receivedAt: Date.now()
+  };
+}
+
+function errorCreatingNotificationList(error) {
+  logError(error);
+  return {
+    type:       'SHOW_ERROR',
+    message:    'Could not delete notification list',
+    error,
+    receivedAt: Date.now()
+  };
+}
+
+export function deleteNotificationList(atom) {
+  return dispatch => {
+    dispatch(requestAtomDeleteNotificationList(atom));
+    return AtomsApi.deleteNotificationList(atom)
+        .then(res => res.json())
+        .then(atom => {
+          dispatch(receiveAtomDeleteNotificationList(atom));
+        })
+        .catch(error => dispatch(errorCreatingNotificationList(error)));
+  };
+}

--- a/public/js/components/AtomActions/AtomActions.js
+++ b/public/js/components/AtomActions/AtomActions.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import NotificationList from './NotificationList';
+
+function AtomActions(prps) {
+  if (!prps.atom) {
+    return false;
+  }
+
+  if (prps.atom.atomType === 'STORYQUESTIONS') {
+    return <NotificationList atom={prps.atom}/>;
+  }
+
+  return false;
+}
+
+export default AtomActions;

--- a/public/js/components/AtomActions/NotificationList.js
+++ b/public/js/components/AtomActions/NotificationList.js
@@ -1,0 +1,78 @@
+import React, { Component, PropTypes } from 'react';
+import {atomPropType} from '../../constants/atomPropType';
+
+class NotificationList extends Component {
+
+  static propTypes = {
+    actions: PropTypes.shape({
+      createNotificationList: PropTypes.func.isRequired,
+      deleteNotificationList: PropTypes.func.isRequired
+    }).isRequired,
+    atom: atomPropType
+  }
+
+  constructor(props) {
+    super(props);
+  }
+
+  getListData(atom) {
+    return (atom.data && atom.data.storyquestions && atom.data.storyquestions.notifications);
+  }
+
+  createNotificationList() {
+    this.props.actions.createNotificationList(this.props.atom);
+  }
+
+  deleteNotificationList() {
+    this.props.actions.deleteNotificationList(this.props.atom);
+  }
+
+  render() {
+    const listData = this.getListData(this.props.atom);
+
+    return (
+      <div className="atom__actions">
+        <div className="form">
+          <div className="form__row">
+            <h3 className="form__subheading">Email notification list</h3>
+            { listData ? (
+              <div>
+                <div className="listId">
+                  <b>{listData.email.name} list ID: </b>
+                  {listData.email.listId}
+                </div>
+                <button className="btn btn--red" onClick={this.deleteNotificationList.bind(this)}>
+                  Delete List
+                </button>
+              </div>
+            ) : (
+              <button className="btn" onClick={this.createNotificationList.bind(this)}>
+                Create List
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+//REDUX CONNECTIONS
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import * as createNotificationList from '../../actions/AtomActions/createNotificationList.js';
+import * as deleteNotificationList from '../../actions/AtomActions/deleteNotificationList.js';
+
+function mapStateToProps(state) {
+  return {
+    atom: state.atom
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    actions: bindActionCreators(Object.assign({}, createNotificationList, deleteNotificationList), dispatch)
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(NotificationList);

--- a/public/js/components/AtomEdit/CustomEditors/StoryQuestionsEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/StoryQuestionsEditor.js
@@ -58,9 +58,6 @@ export class StoryQuestionsEditor extends React.Component {
           <ManagedField fieldLocation="data.storyquestions.editorialQuestions[0]" name="Editorial Questions">
             <StoryQuestionsQuestionSet onFormErrorsUpdate={this.props.onFormErrorsUpdate} />
           </ManagedField>
-          <ManagedField fieldLocation="labels[0]" name="Email List ID">
-            <FormFieldTextInput/>
-          </ManagedField>
         </ManagedForm>
       </div>
     );

--- a/public/js/components/AtomRoot/AtomRoot.js
+++ b/public/js/components/AtomRoot/AtomRoot.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import AtomEmbed from '../AtomEmbed/AtomEmbed';
+import AtomActions from '../AtomActions/AtomActions';
 
 import {atomPropType} from '../../constants/atomPropType.js';
 
@@ -35,6 +36,7 @@ class AtomRoot extends React.Component {
         <div className="atom__content">
           {this.props.children}
         </div>
+        <AtomActions atom={this.props.atom}/>
       </div>
     );
   }

--- a/public/js/reducers/atomReducer.js
+++ b/public/js/reducers/atomReducer.js
@@ -25,6 +25,12 @@ export default function atom(state = null, action) {
         contentChangeDetails: action.atom.contentChangeDetails
       }) || false;
 
+    case 'ATOM_CREATE_NOTIFICATION_RECEIVE':
+      return action.atom || false;
+
+    case 'ATOM_DELETE_NOTIFICATION_RECEIVE':
+      return action.atom || false;
+
     default:
       return state;
   }

--- a/public/js/services/AtomsApi.js
+++ b/public/js/services/AtomsApi.js
@@ -67,5 +67,24 @@ export default {
         }
       }
     );
-  }
+  },
+
+  createNotificationList: (atom) =>
+      pandaFetch(
+        `/api/live/${atom.atomType}/${atom.id}/custom/notifications`,
+        {
+          method: 'post',
+          credentials: 'same-origin'
+        }
+      )
+  ,
+
+  deleteNotificationList: (atom) =>
+      pandaFetch(
+        `/api/live/${atom.atomType}/${atom.id}/custom/notifications`,
+        {
+          method: 'delete',
+          credentials: 'same-origin'
+        }
+      )
 };

--- a/public/styles/components/_atom-actions.scss
+++ b/public/styles/components/_atom-actions.scss
@@ -1,0 +1,11 @@
+.atom__actions {
+  width: 300px;
+  min-height: calc(100vh - #{$toolbarHeight});
+  background-color: $color200Grey;
+  border-left: 1px solid $color300Grey;
+  padding: 10px;
+
+  .listId {
+    margin-bottom: 5px;
+  }
+}

--- a/public/styles/main.scss
+++ b/public/styles/main.scss
@@ -37,4 +37,5 @@
 'components/atom-card',
 'components/atom-editor',
 'components/atom-embed',
+'components/atom-actions',
 'components/targeting';


### PR DESCRIPTION
This adds a new optional "atom actions" sidebar to the right of the atom editor screen.
This is currently only used for storyquestions atoms to support the creation/deletion of an Exact Target list (currently this is done manually).

The interaction with Exact Target is done via a separate library.

### Before creating a list:
![picture 5](https://user-images.githubusercontent.com/1513454/30368620-93ce3730-9869-11e7-930c-fe7a2be9c4ff.png)

### After creating a list:
![picture 6](https://user-images.githubusercontent.com/1513454/30368619-93c6dae4-9869-11e7-8d30-71b6a0fa7d9f.png)
