### PR TITLE
Default values for snippet items

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
@@ -22,8 +22,8 @@ export class GuideItem extends React.Component {
 
   render () {
     const value = this.props.fieldValue || {
-      title: "",
-      body: ""
+      title: null,
+      body: "-"
     };
     return (
       <div className="form__field form__field--nested">

--- a/public/js/components/AtomEdit/CustomEditors/ProfileFields/ProfileItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/ProfileFields/ProfileItem.js
@@ -22,8 +22,8 @@ export class ProfileItem extends React.Component {
 
   render () {
     const value = this.props.fieldValue || {
-      title: "",
-      body: ""
+      title: null,
+      body: "-"
     };
     return (
       <div className="form__field form__field--nested">

--- a/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
@@ -24,9 +24,9 @@ export class TimelineItem extends React.Component {
 
   render () {
     const value = this.props.fieldValue || {
-      title: "",
+      title: "-",
       date: Date.now(),
-      body: ""
+      body: "-"
     };
     return (
       <div className="form__field form__field--nested">


### PR DESCRIPTION
Currently when you add a new item (click `Add` on the `FormFieldArrayWrapper`) on a guide/profile/timeline it immediately says `Could not update atom` at the top. The error does not go away. This is causing confusion, and members of Editorial assume it is not working at all.

There are 2 issues here:
1. Dynamodb does not accept an empty string as a valid field value. The solution is to use `null` instead for unset optional fields (e.g. title in a `GuideItem`). This means they will be set to `None` during deserialization server-side.
2. If an item in the array does not pass validation (client-side) then the client sends `[null]`, which again fails deserialization. Fixing this will require a bit more thought, because of how atom-workshop manages the atom state. For now I've just made the default values on new items valid.