### PR TITLE
Link answers to questions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.0"
 scalaVersion := "2.11.8"
 
 lazy val awsVersion = "1.11.8"
-lazy val atomLibVersion = "1.1.3"
+lazy val atomLibVersion = "1.1.7"
 
 libraryDependencies ++= Seq(
   ws,
@@ -13,7 +13,7 @@ libraryDependencies ++= Seq(
   "com.gu"                   %% "atom-manager-play"           % atomLibVersion,
   "com.gu"                   %% "atom-publisher-lib"          % atomLibVersion,
   "com.gu"                   %% "configuration-magic-core"    % "1.3.0",
-  "com.gu"                   %% "fezziwig"                    % "0.2",
+  "com.gu"                   %% "fezziwig"                    % "0.7",
   "com.gu"                   %  "kinesis-logback-appender"    % "1.3.0",
   "com.gu"                   %% "pan-domain-auth-play_2-5"    % "0.4.1",
   "io.circe"                 %% "circe-parser"                % "0.7.0",

--- a/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Answer.js
+++ b/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Answer.js
@@ -1,0 +1,49 @@
+import React, { PropTypes } from 'react';
+import {ManagedForm, ManagedField} from '../../../ManagedEditor';
+import FormFieldTextInput from '../../../FormFields/FormFieldTextInput';
+import SearchSelectBox from '../../../FormFields/SearchFields/SearchSelectBox';
+import _get from 'lodash/fp/get';
+
+export class StoryQuestionsAnswer extends React.Component {
+  static propTypes = {
+    fieldLabel: PropTypes.string,
+    fieldName: PropTypes.string,
+    fieldValue: PropTypes.shape({
+      answerId: PropTypes.string,
+      answerType: PropTypes.string
+    }),
+    fieldPlaceholder: PropTypes.string,
+    onUpdateField: PropTypes.func,
+    onFormErrorsUpdate: PropTypes.func
+  };
+
+  onUpdate = (answer) => {
+    const answerWithType = Object.assign({}, answer, {
+      answerType: answer.answerType || "ATOM"
+    });
+
+    this.props.onUpdateField(answerWithType);
+  }
+
+  getPlaceholder = (answerType) => answerType === "CONTENT"
+    ? "e.g. world/2017/sep/21/an-explainer-article"
+    : "e.g. atom/guide/d12c3782-2d4b-4335-9701-830ac29c7d3b";
+
+  render () {
+    const answerType = _get(this.props, "fieldValue.answerType", "ATOM");
+    const placeholder = this.getPlaceholder(answerType);
+
+    return (
+      <div className="form__field form__field--nested">
+        <ManagedForm data={this.props.fieldValue} updateData={this.onUpdate} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="storyquestionsEditor">
+          <ManagedField fieldLocation="answerType" name="Answer type" isRequired={true}>
+            <SearchSelectBox selectValues={["ATOM", "CONTENT"]} isRequired={true}/>
+          </ManagedField>
+          <ManagedField fieldLocation="answerId" name="Answer ID" isRequired={true}>
+            <FormFieldTextInput fieldPlaceholder={placeholder}/>
+          </ManagedField>
+        </ManagedForm>
+      </div>
+    );
+  }
+}

--- a/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Question.js
+++ b/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Question.js
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react';
 import {ManagedForm, ManagedField} from '../../../ManagedEditor';
 import FormFieldTextInput from '../../../FormFields/FormFieldTextInput';
+import FormFieldArrayWrapper from '../../../FormFields/FormFieldArrayWrapper';
+import {StoryQuestionsAnswer} from './Answer';
 import uuidv4 from 'uuid/v4';
 
 export class StoryQuestionsQuestion extends React.Component {
@@ -9,7 +11,8 @@ export class StoryQuestionsQuestion extends React.Component {
     fieldName: PropTypes.string,
     fieldValue: PropTypes.shape({
       questionId: PropTypes.string,
-      questionText: PropTypes.string
+      questionText: PropTypes.string,
+      answers: PropTypes.array
     }),
     fieldPlaceholder: PropTypes.string,
     onUpdateField: PropTypes.func,
@@ -25,11 +28,18 @@ export class StoryQuestionsQuestion extends React.Component {
   }
 
   render () {
+    const answersCount = (this.props.fieldValue && this.props.fieldValue.answers) ? this.props.fieldValue.answers.length : 0;
+
     return (
       <div className="form__field form__field--nested">
         <ManagedForm data={this.props.fieldValue} updateData={this.updateQuestion} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="storyquestionsEditor">
           <ManagedField fieldLocation="questionText" name="Question" isRequired={true}>
             <FormFieldTextInput />
+          </ManagedField>
+          <ManagedField fieldLocation="answers" name={`Answers (${answersCount})`} >
+            <FormFieldArrayWrapper>
+              <StoryQuestionsAnswer/>
+            </FormFieldArrayWrapper>
           </ManagedField>
         </ManagedForm>
       </div>


### PR DESCRIPTION
A very basic UI for linking an atom ID or content ID to a question. 
The answers are added at the question-level, rather than the atom-level.

TODO:
1. Perhaps in future it could help the user search for the atom/content so that they don't have to use IDs.
2. Trigger email send after linking an answer

This work took way longer than expected because:
1. I discovered an issue with deserialization to scrooge classes which can sometimes cause data to be lost, hence the fezziwig version bump (https://github.com/guardian/fezziwig/pull/16)
2. I've 'fixed' a long-standing issue with `FormFieldArrayWrapper` which causes updates to be sent back to the server immediately when the user clicks "add". This leads to error messages because `undefined` is appended. The solution is quite hacky, but I seem to have fixed it by using internal state for new items.

With no answers:
<img width="448" alt="picture 17" src="https://user-images.githubusercontent.com/1513454/30917805-bd8e06dc-a394-11e7-8582-d36a0d8ca446.png">

After clicking add:
<img width="431" alt="picture 18" src="https://user-images.githubusercontent.com/1513454/30917815-c1715d94-a394-11e7-9cb3-e54ba850bfdf.png">

With an answer:
<img width="401" alt="picture 19" src="https://user-images.githubusercontent.com/1513454/30917914-faec840e-a394-11e7-94eb-fde84e516a61.png">
