### PR TITLE
Missed timeline item is not missed anymore

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
@@ -39,7 +39,7 @@ export class TimelineItem extends React.Component {
             <FormFieldTextInput/>
           </ManagedField>
           <ManagedField fieldLocation="body" name="Body">
-            <FormFieldsScribeEditor showWordCount={true} suggestedLength={150} showToolbar={false}/>
+            <FormFieldsScribeEditor showWordCount={true} suggestedLength={150} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"}/>
           </ManagedField>
         </ManagedForm>
       </div>


### PR DESCRIPTION
I added the message to the description field but not the individual items.

🤔  we should also think about the "length" of the snippet as a whole; it is definitely _not_ fine to create a timeline of 20 items.