### PR TITLE
Integrate workflow

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -60,6 +60,7 @@ object Config extends AwsInstanceTags {
   val composerUrl = config.getString("composer.url")
   val viewerUrl = config.getString("viewer.url")
   val targetingUrl = config.getString("targeting.url")
+  val workflowUrl = config.getString("workflow.url")
 
   val liveKinesisStreamName = getPropertyIfEnabled(kinesisEnabled, "aws.kinesis.publish.live")
   val previewKinesisStreamName = getPropertyIfEnabled(kinesisEnabled, "aws.kinesis.publish.preview")

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -17,9 +17,18 @@ import util.AtomElementBuilders
 import util.AtomLogic._
 import util.AtomUpdateOperations._
 import util.Parser._
+import util.CORSable
+import play.api.mvc.Action
 
 class App(val wsClient: WSClient, val atomWorkshopDB: AtomWorkshopDBAPI) extends Controller with PanDomainAuthActions {
 
+  def allowCORSAccess(methods: String, args: Any*) = CORSable(Config.workflowUrl) {
+    Action { implicit req =>
+      val requestedHeaders = req.headers("Access-Control-Request-Headers")
+      NoContent.withHeaders("Access-Control-Allow-Methods" -> methods, "Access-Control-Allow-Headers" -> requestedHeaders)
+    }
+  }
+  
   def index(placeholder: String) = AuthAction { req =>
     Logger.info(s"I am the ${Config.appName}")
     val clientConfig = ClientConfig(
@@ -60,15 +69,18 @@ class App(val wsClient: WSClient, val atomWorkshopDB: AtomWorkshopDBAPI) extends
     }
   }
 
-  def createAtom(atomType: String) = AuthAction { req =>
-    APIResponse{
-      for {
-        atomType <- validateAtomType(atomType)
-        createAtomFields <- extractCreateAtomFields(req.body.asJson.map(_.toString))
-        atomToCreate = AtomElementBuilders.buildDefaultAtom(atomType, req.user, createAtomFields)
-        atom <- atomWorkshopDB.createAtom(previewDataStore, atomType, req.user, atomToCreate)
-        _ <- sendKinesisEvent(atom, previewAtomPublisher, EventType.Update)
-      } yield atom
+
+  def createAtom(atomType: String) = CORSable(Config.workflowUrl) {
+    AuthAction { req =>
+      APIResponse{
+        for {
+          atomType <- validateAtomType(atomType)
+          createAtomFields <- extractCreateAtomFields(req.body.asJson.map(_.toString))
+          atomToCreate = AtomElementBuilders.buildDefaultAtom(atomType, req.user, createAtomFields)
+          atom <- atomWorkshopDB.createAtom(previewDataStore, atomType, req.user, atomToCreate)
+          _ <- sendKinesisEvent(atom, previewAtomPublisher, EventType.Update)
+        } yield atom
+      }
     }
   }
 

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -38,6 +38,7 @@ class App(val wsClient: WSClient, val atomWorkshopDB: AtomWorkshopDBAPI) extends
       viewerUrl = Config.viewerUrl,
       capiLiveUrl = Config.capiLiveUrl,
       targetingUrl = Config.targetingUrl,
+      workflowUrl = Config.workflowUrl,
       isEmbedded = req.queryString.get("embeddedMode").isDefined,
       embeddedMode = req.queryString.get("embeddedMode").map(_.head),
       atomEditorGutoolsDomain = Config.atomEditorGutoolsDomain,

--- a/app/models/ClientConfig.scala
+++ b/app/models/ClientConfig.scala
@@ -16,6 +16,7 @@ case class ClientConfig(
                          viewerUrl: String,
                          capiLiveUrl: String,
                          targetingUrl: String,
+                         workflowUrl: String,
                          isEmbedded: Boolean,
                          embeddedMode: Option[String],
                          atomEditorGutoolsDomain: String,

--- a/app/util/CORSable.scala
+++ b/app/util/CORSable.scala
@@ -1,0 +1,20 @@
+package util
+
+import play.api.mvc.{Action, BodyParser, Request, Result}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+case class CORSable[A](origins: String*)(action: Action[A]) extends Action[A] {
+
+  def apply(request: Request[A]): Future[Result] = {
+    val headers = request.headers.get("Origin").map { origin =>
+      if(origins.contains(origin)) {
+        List("Access-Control-Allow-Origin" -> origin, "Access-Control-Allow-Credentials" -> "true")
+      } else { Nil }
+    }
+    action(request).map(_.withHeaders(headers.getOrElse(Nil) :_*))
+  }
+
+  lazy val parser: BodyParser[A] = action.parser
+}

--- a/conf/routes
+++ b/conf/routes
@@ -8,6 +8,8 @@ GET     /atoms/:placeholder/:placeholder/edit    controllers.App.index(placehold
 GET     /atoms/:placeholder/:placeholder/stats   controllers.App.index(placeholder)
 GET     /external-atoms/:placeholder/:placeholder/link    controllers.App.index(placeholder)
 
+OPTIONS /api/preview/*url                        controllers.App.allowCORSAccess(methods = "PUT, POST, DELETE", url: String)
+
 GET  /api/preview/:atomType/:id                  controllers.App.getAtom(atomType: String, id: String, version = "preview")
 GET  /api/live/:atomType/:id                     controllers.App.getAtom(atomType: String, id: String, version = "live")
 

--- a/public/js/actions/WorkflowActions/getStatus.js
+++ b/public/js/actions/WorkflowActions/getStatus.js
@@ -1,0 +1,53 @@
+import WorkflowApi from '../../services/WorkflowApi';
+import {logError} from '../../util/logger';
+import {WorkflowStatus} from '../../constants/workflow';
+
+
+function requestWorkflowStatus() {
+  return {
+    type:       'WORKFLOW_STATUS_GET_REQUEST',
+    receivedAt: Date.now()
+  };
+}
+
+function receiveWorkflowStatus(status) {
+  return {
+    type:       'WORKFLOW_STATUS_GET_RECEIVE',
+    receivedAt: Date.now(),
+    status:     status
+  };
+}
+
+function errorReceivingWorkflowStatus(error) {
+  logError(error);
+  return {
+    type:       'SHOW_ERROR',
+    message:    'Could not track atom in workflow',
+    error:      error,
+    receivedAt: Date.now()
+  };
+}
+
+function receiveStatus404() {
+  return {
+    type: 'WORKFLOW_STATUS_GET_RECEIVE',
+    receivedAt: Date.now(),
+    status: WorkflowStatus.notInWorkflow
+  };
+}
+
+export function getWorkflowStatus(atom) {
+  return dispatch => {
+    dispatch(requestWorkflowStatus());
+    return WorkflowApi.getWorkflowStatus(atom)
+    .then(response => {
+      dispatch(receiveWorkflowStatus(response.data));
+    })
+    .catch(error => {
+      if (error.status ===  404) {
+        return dispatch(receiveStatus404());
+      }
+      return dispatch(errorReceivingWorkflowStatus(error))
+    });
+  };
+}

--- a/public/js/actions/WorkflowActions/getStatus.js
+++ b/public/js/actions/WorkflowActions/getStatus.js
@@ -22,7 +22,7 @@ function errorReceivingWorkflowStatus(error) {
   logError(error);
   return {
     type:       'SHOW_ERROR',
-    message:    'Could not track atom in workflow',
+    message:    'Could not get workflow statuses',
     error:      error,
     receivedAt: Date.now()
   };
@@ -47,7 +47,7 @@ export function getWorkflowStatus(atom) {
       if (error.status ===  404) {
         return dispatch(receiveStatus404());
       }
-      return dispatch(errorReceivingWorkflowStatus(error))
+      return dispatch(errorReceivingWorkflowStatus(error));
     });
   };
 }

--- a/public/js/actions/WorkflowActions/trackInWorkflow.js
+++ b/public/js/actions/WorkflowActions/trackInWorkflow.js
@@ -1,0 +1,41 @@
+import WorkflowApi from '../../services/WorkflowApi';
+import {logError} from '../../util/logger';
+
+function requestTrackInWorkflow(atomType, id) {
+  return {
+    type:       'WORKFLOW_TRACK_GET_REQUEST',
+    atomType:   atomType,
+    id:         id,
+    receivedAt: Date.now()
+  };
+}
+
+function receiveTrackInWorkflow(data) {
+  return {
+    type:       'WORKFLOW_TRACK_GET_RECEIVE',
+    data:       data,
+    receivedAt: Date.now()
+  };
+}
+
+function errorReceivingTrackInWorkflow(error) {
+  logError(error);
+  return {
+    type:       'SHOW_ERROR',
+    message:    'Could not track atom in workflow',
+    error:      error,
+    receivedAt: Date.now()
+  };
+}
+
+export function trackInWorkflow(atom, section, scheduledLaunchDate) {
+  return dispatch => {
+    dispatch(requestTrackInWorkflow(atom.atomType, atom.id));
+    return WorkflowApi.trackInWorkflow(atom, section, scheduledLaunchDate, 'writers')
+    .then(res => res.json())
+    .then(atom => {
+      dispatch(receiveTrackInWorkflow(atom));
+    })
+    .catch(error => dispatch(errorReceivingTrackInWorkflow(error)));
+  };
+}

--- a/public/js/actions/WorkflowActions/trackInWorkflow.js
+++ b/public/js/actions/WorkflowActions/trackInWorkflow.js
@@ -31,7 +31,7 @@ function errorReceivingTrackInWorkflow(error) {
 export function trackInWorkflow(atom, section, scheduledLaunchDate) {
   return dispatch => {
     dispatch(requestTrackInWorkflow(atom.atomType, atom.id));
-    return WorkflowApi.trackInWorkflow(atom, section, scheduledLaunchDate, 'writers')
+    return WorkflowApi.trackInWorkflow(atom, section, scheduledLaunchDate, 'Writers')
     .then(res => res.json())
     .then(atom => {
       dispatch(receiveTrackInWorkflow(atom));

--- a/public/js/components/AtomEmbed/AtomEmbed.js
+++ b/public/js/components/AtomEmbed/AtomEmbed.js
@@ -18,6 +18,13 @@ class AtomEmbed extends React.Component {
       getWorkflowStatus: PropTypes.func.isRequired,
       trackInWorkflow: PropTypes.func.isRequired
     }),
+    workflow: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({
+      title: PropTypes.string,
+      prodOffice: PropTypes.string,
+      section: PropTypes.string,
+      status: PropTypes.string,
+      scheduledLaunch: PropTypes.string
+    })])
   }
 
   state = {

--- a/public/js/components/AtomEmbed/AtomEmbed.js
+++ b/public/js/components/AtomEmbed/AtomEmbed.js
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react';
 import {atomPropType} from '../../constants/atomPropType.js';
 import copy from 'copy-to-clipboard';
 import {Link} from 'react-router';
+import Workflow from '../Workflow/Workflow';
 
 import CurrentTargets from './CurrentTargets';
 
@@ -60,6 +61,10 @@ class AtomEmbed extends React.Component {
                 {this.state.copied ? "Copied!" : "Copy URL"}
               </button>
             </div>
+          </div>
+          <div className="form__row">
+            <h3 className="form__subheading">Workflow</h3>
+            <Workflow atom={this.props.atom} config={this.props.config} workflow={this.props.workflow} workflowActions={this.props.workflowActions}/>
           </div>
           <div className="form__row">
             <h3 className="form__subheading">Suggest This Atom</h3>

--- a/public/js/components/AtomEmbed/AtomEmbed.js
+++ b/public/js/components/AtomEmbed/AtomEmbed.js
@@ -13,7 +13,11 @@ class AtomEmbed extends React.Component {
     config: PropTypes.shape({
       capiLiveUrl: PropTypes.string.isRequired,
       isEmbedded: PropTypes.bool.isRequired
-    })
+    }),
+    workflowActions: PropTypes.shape({
+      getWorkflowStatus: PropTypes.func.isRequired,
+      trackInWorkflow: PropTypes.func.isRequired
+    }),
   }
 
   state = {

--- a/public/js/components/AtomRoot/AtomRoot.js
+++ b/public/js/components/AtomRoot/AtomRoot.js
@@ -1,9 +1,7 @@
 import React, { PropTypes } from 'react';
 import AtomEmbed from '../AtomEmbed/AtomEmbed';
 import AtomActions from '../AtomActions/AtomActions';
-
 import {atomPropType} from '../../constants/atomPropType.js';
-
 
 class AtomRoot extends React.Component {
 
@@ -24,7 +22,10 @@ class AtomRoot extends React.Component {
 
 
   componentWillMount() {
-    this.props.atomActions.getAtom(this.props.routeParams.atomType, this.props.routeParams.id);
+    this.props.atomActions.getAtom(this.props.routeParams.atomType, this.props.routeParams.id)
+    .then(() => {
+      this.props.workflowActions.getWorkflowStatus(this.props.atom);
+    });
   }
 
 
@@ -32,7 +33,7 @@ class AtomRoot extends React.Component {
 
     return (
       <div className="atom">
-        <AtomEmbed atom={this.props.atom} config={this.props.config}/>
+        <AtomEmbed atom={this.props.atom} config={this.props.config} workflow={this.props.workflow} workflowActions={this.props.workflowActions}/>
         <div className="atom__content">
           {this.props.children}
         </div>
@@ -47,17 +48,21 @@ class AtomRoot extends React.Component {
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as getAtomActions from '../../actions/AtomActions/getAtom.js';
+import * as trackInWorkflowActions from '../../actions/WorkflowActions/trackInWorkflow.js';
+import * as getStatusActions from '../../actions/WorkflowActions/getStatus.js';
 
 function mapStateToProps(state) {
   return {
     config: state.config,
-    atom: state.atom
+    atom: state.atom,
+    workflow: state.workflow
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
-    atomActions: bindActionCreators(Object.assign({}, getAtomActions), dispatch)
+    atomActions: bindActionCreators(Object.assign({}, getAtomActions), dispatch),
+    workflowActions: bindActionCreators(Object.assign({}, trackInWorkflowActions, getStatusActions), dispatch)
   };
 }
 

--- a/public/js/components/AtomRoot/AtomRoot.js
+++ b/public/js/components/AtomRoot/AtomRoot.js
@@ -13,6 +13,17 @@ class AtomRoot extends React.Component {
     atomActions: PropTypes.shape({
       getAtom: PropTypes.func.isRequired,
     }).isRequired,
+    workflowActions: PropTypes.shape({
+      getWorkflowStatus: PropTypes.func.isRequired,
+      trackInWorkflow: PropTypes.func.isRequired
+    }),
+    workflow: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({
+      title: PropTypes.string,
+      prodOffice: PropTypes.string,
+      section: PropTypes.string,
+      status: PropTypes.string,
+      scheduledLaunch: PropTypes.string
+    })]),
     atom: atomPropType,
     config: PropTypes.shape({
       liveCapiUrl: PropTypes.string

--- a/public/js/components/FormFields/FormFieldDateInput.js
+++ b/public/js/components/FormFields/FormFieldDateInput.js
@@ -17,7 +17,8 @@ export default class FormFieldDateInput extends React.Component {
     fieldErrors: PropTypes.arrayOf(errorPropType),
     formRowClass: PropTypes.string,
     onUpdateField: PropTypes.func,
-    isOutsideRange: PropTypes.func
+    isOutsideRange: PropTypes.func,
+    placeholder: PropTypes.string
   };
 
   state = {

--- a/public/js/components/FormFields/FormFieldDateInput.js
+++ b/public/js/components/FormFields/FormFieldDateInput.js
@@ -28,6 +28,17 @@ export default class FormFieldDateInput extends React.Component {
     this.props.onUpdateField(momentDate.valueOf());
   }
 
+  getPlaceholder = () => {
+    if (this.props.fieldValue) {
+      return format(this.props.fieldValue, 'DD/MM/YYYY');
+    }
+    if (this.props.placeholder) {
+      return this.props.placeholder;
+    }
+    return 'Pick Expiry Date';
+
+  }
+
   render() {
     return (
         <div className={this.props.formRowClass || "form__row"}>
@@ -39,7 +50,7 @@ export default class FormFieldDateInput extends React.Component {
             onDateChange={this.onDateChange}
             onFocusChange={({ focused }) => { this.setState({ focused }); }}
             numberOfMonths={1}
-            placeholder={this.props.fieldValue ? format(this.props.fieldValue, "DD/MM/YYYY") : "Pick Expiry Date" }
+            placeholder={this.getPlaceholder()}
             isOutsideRange={this.props.isOutsideRange}
           />
           <ShowErrors errors={this.props.fieldErrors}/>

--- a/public/js/components/FormFields/FormFieldSelectBox.js
+++ b/public/js/components/FormFields/FormFieldSelectBox.js
@@ -7,23 +7,51 @@ export default class FormFieldSelectBox extends React.Component {
   static propTypes = {
     fieldLabel: PropTypes.string,
     fieldName: PropTypes.string,
-    fieldValue: PropTypes.string,
+    fieldValue: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     fieldErrors: PropTypes.arrayOf(errorPropType),
     selectValues: PropTypes.array,
     formRowClass: PropTypes.string,
-    onUpdateField: PropTypes.func
+    onUpdateField: PropTypes.func,
+    optionsAsObject: PropTypes.bool,
+    displayEmptyOption: PropTypes.bool
   };
 
   renderOption(option) {
+    if (option.id) {
+      return (
+        <option key={option.id} value={option.id}>{option.name}</option>
+      );
+    }
+
     return (
-        <option key={option} value={option}>{option}</option>
+      <option key={option} value={option}>{option}</option>
     );
   }
 
   onUpdate = (e) => {
-    this.props.onUpdateField(e.target.value);
+    if (this.props.optionsAsObject) {
+      const id = parseInt(e.target.value);
+      const newValue = this.props.selectValues.find(value => {
+        return value.id === id;
+      });
+
+      this.props.onUpdateField(newValue);
+
+    } else {
+      this.props.onUpdateField(e.target.value);
+    }
   }
 
+
+  renderDefaultOption() {
+    if (this.props.displayEmptyOption && !this.props.fieldValue) {
+      return (
+        <option value={null}>
+          Please select...
+        </option>
+      );
+    }
+  }
 
   renderOptions() {
     return this.props.selectValues.map(this.renderOption);
@@ -33,7 +61,8 @@ export default class FormFieldSelectBox extends React.Component {
     return (
         <div className={this.props.formRowClass || "form__row"}>
           {this.props.fieldLabel ? <label htmlFor={this.props.fieldName} className="form__label">{this.props.fieldLabel}</label> : false}
-          <select className="form__field form__field--select" value={this.props.fieldValue} onChange={this.onUpdate}>
+          <select className="form__field form__field--select" value={this.props.optionsAsObject ? this.props.fieldValue.id : this.props.fieldValue} onChange={this.onUpdate}>
+            {this.renderDefaultOption()}
             {this.renderOptions()}
           </select>
           <ShowErrors errors={this.props.fieldErrors}/>

--- a/public/js/components/Workflow/Workflow.js
+++ b/public/js/components/Workflow/Workflow.js
@@ -6,7 +6,8 @@ import { getStore } from '../../util/storeAccessor';
 import {ManagedForm, ManagedField} from '../ManagedEditor';
 import FormFieldSelectBox from '../FormFields/FormFieldSelectBox';
 import FormFieldDateInput from '../FormFields/FormFieldDateInput';
-import format from 'date-fns/format'
+import format from 'date-fns/format';
+import _camelCase from 'lodash/fp/camelcase';
 
 class Workflow extends React.Component {
 
@@ -24,6 +25,7 @@ class Workflow extends React.Component {
 
   state = {
     workflowSections: [],
+    trackableAtomTypes: [],
     atomWorkflowInfo: {
       section: ''
     }
@@ -34,6 +36,13 @@ class Workflow extends React.Component {
     .then(sections => {
       this.setState({
         workflowSections: sections
+      });
+    });
+
+    WorkflowApi.getTrackableAtomTypes()
+    .then(atomTypes => {
+      this.setState({
+        trackableAtomTypes: atomTypes
       });
     });
   }
@@ -70,6 +79,13 @@ class Workflow extends React.Component {
   render() {
     const workflow = this.props.workflow;
     const title = workflow.title;
+    const atomType = _.camelCase(this.props.atom.atomType);
+
+    if (!this.state.trackableAtomTypes.includes(atomType)) {
+      return (
+        <div>Atoms with this type are not supported by workflow</div>
+      );
+    }
 
     if (this.props.workflow && this.props.workflow !== WorkflowStatus.notInWorkflow) {
       return (

--- a/public/js/components/Workflow/Workflow.js
+++ b/public/js/components/Workflow/Workflow.js
@@ -1,0 +1,117 @@
+import React, {PropTypes} from 'react';
+import {atomPropType} from '../../constants/atomPropType.js';
+import {WorkflowStatus} from '../../constants/workflow';
+import WorkflowApi from '../../services/WorkflowApi';
+import { getStore } from '../../util/storeAccessor';
+import {ManagedForm, ManagedField} from '../ManagedEditor';
+import FormFieldSelectBox from '../FormFields/FormFieldSelectBox';
+import FormFieldDateInput from '../FormFields/FormFieldDateInput';
+import format from 'date-fns/format'
+
+class Workflow extends React.Component {
+
+  static propTypes = {
+    atom: atomPropType
+
+  }
+
+  state = {
+    workflowSections: [],
+    atomWorkflowInfo: {
+      section: ''
+    }
+  }
+
+  componentWillMount() {
+    WorkflowApi.getSections()
+    .then(sections => {
+      this.setState({
+        workflowSections: sections
+      });
+    });
+  }
+
+  updateWorkflowInfo = (info) => {
+    this.setState({
+      atomWorkflowInfo: info
+    });
+  }
+
+  trackInWorkflow = () => {
+    this.props.workflowActions.trackInWorkflow(
+        this.props.atom,
+        this.state.atomWorkflowInfo.section,
+        this.state.atomWorkflowInfo.scheduledLaunchDate
+    )
+    .then(() => this.props.workflowActions.getWorkflowStatus(this.props.atom));
+  }
+
+  getWorkflowLink = () => {
+    if (this.props.atom) {
+      const workflowUrl = getStore().getState().config.workflowUrl;
+      return `${workflowUrl}/dashboard?editorId=${this.props.atom.id}`;
+    } return '';
+  }
+
+  getScheduledLaunchDate = () => {
+    if (this.props.workflow.scheduledLaunchDate) {
+      return format(this.props.workflow.scheduledLaunchDate, 'DD/MM/YYYY');
+    }
+    return 'Not set';
+  }
+
+  render() {
+    const workflow = this.props.workflow;
+    const title = workflow.title;
+
+    if (this.props.workflow && this.props.workflow !== WorkflowStatus.notInWorkflow) {
+      return (
+        <div>
+          <table className="workflow__info">
+            <thead>
+              <tr>
+                <th>Title</th>
+                <th>Production Office</th>
+                <th>Section</th>
+                <th>Status</th>
+                <th>Scheduled Launch</th>
+              </tr>
+             </thead>
+             <tbody>
+               <tr>
+                 <td>{this.props.workflow.title}</td>
+                 <td>{this.props.workflow.prodOffice}</td>
+                 <td>{this.props.workflow.section}</td>
+                 <td>{this.props.workflow.status}</td>
+                 <td>{this.getScheduledLaunchDate()}</td>
+               </tr>
+             </tbody>
+           </table>
+           <a target="_blank"
+             rel="noopener noreferrer"
+             href={this.getWorkflowLink()}>
+             Open in Workflow
+           </a>
+         </div>
+        );
+    }
+
+    return (
+      <div>
+        <ManagedForm data={this.state.atomWorkflowInfo} updateData={this.updateWorkflowInfo}>
+          <ManagedField fieldLocation="section" name="Section">
+            <FormFieldSelectBox selectValues={this.state.workflowSections} optionsAsObject={true} displayEmptyOption={true}/>
+          </ManagedField>
+          <ManagedField fieldLocation="scheduledLaunchDate" name="Scheduled Launch Date">
+            <FormFieldDateInput placeholder="Pick launch date"/>
+          </ManagedField>
+        </ManagedForm>
+        <button className="btn" onClick={this.trackInWorkflow} disabled={!this.state.atomWorkflowInfo.section}>
+          Track in Workflow
+        </button>
+      </div>
+    );
+  };
+}
+
+export default Workflow;

--- a/public/js/components/Workflow/Workflow.js
+++ b/public/js/components/Workflow/Workflow.js
@@ -11,8 +11,15 @@ import format from 'date-fns/format'
 class Workflow extends React.Component {
 
   static propTypes = {
-    atom: atomPropType
-
+    atom: atomPropType,
+    config: PropTypes.shape({
+      capiLiveUrl: PropTypes.string.isRequired,
+      isEmbedded: PropTypes.bool.isRequired
+    }),
+    workflowActions: PropTypes.shape({
+      getWorkflowStatus: PropTypes.func.isRequired,
+      trackInWorkflow: PropTypes.func.isRequired
+    })
   }
 
   state = {

--- a/public/js/components/Workflow/Workflow.js
+++ b/public/js/components/Workflow/Workflow.js
@@ -7,7 +7,7 @@ import {ManagedForm, ManagedField} from '../ManagedEditor';
 import FormFieldSelectBox from '../FormFields/FormFieldSelectBox';
 import FormFieldDateInput from '../FormFields/FormFieldDateInput';
 import format from 'date-fns/format';
-import _camelCase from 'lodash/fp/camelcase';
+import _ from 'lodash';
 
 class Workflow extends React.Component {
 
@@ -20,7 +20,14 @@ class Workflow extends React.Component {
     workflowActions: PropTypes.shape({
       getWorkflowStatus: PropTypes.func.isRequired,
       trackInWorkflow: PropTypes.func.isRequired
-    })
+    }),
+    workflow: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({
+      title: PropTypes.string,
+      prodOffice: PropTypes.string,
+      section: PropTypes.string,
+      status: PropTypes.string,
+      scheduledLaunch: PropTypes.string
+    })])
   }
 
   state = {
@@ -32,18 +39,20 @@ class Workflow extends React.Component {
   }
 
   componentWillMount() {
-    WorkflowApi.getSections()
-    .then(sections => {
-      this.setState({
-        workflowSections: sections
-      });
-    });
-
     WorkflowApi.getTrackableAtomTypes()
     .then(atomTypes => {
       this.setState({
         trackableAtomTypes: atomTypes
       });
+
+      if (this.state.trackableAtomTypes.includes(_.camelCase(this.props.atom.atomType))) {
+        WorkflowApi.getSections()
+        .then(sections => {
+          this.setState({
+            workflowSections: sections
+          });
+        });
+      }
     });
   }
 
@@ -77,8 +86,6 @@ class Workflow extends React.Component {
   }
 
   render() {
-    const workflow = this.props.workflow;
-    const title = workflow.title;
     const atomType = _.camelCase(this.props.atom.atomType);
 
     if (!this.state.trackableAtomTypes.includes(atomType)) {
@@ -134,7 +141,7 @@ class Workflow extends React.Component {
         </button>
       </div>
     );
-  };
+  }
 }
 
 export default Workflow;

--- a/public/js/constants/workflow.js
+++ b/public/js/constants/workflow.js
@@ -1,0 +1,5 @@
+export class WorkflowStatus {
+  static get notInWorkflow() {
+    return 'NotInWorkflow';
+  }
+}

--- a/public/js/reducers/rootReducer.js
+++ b/public/js/reducers/rootReducer.js
@@ -12,6 +12,7 @@ import atomUsages from '../reducers/atomUsagesReducer';
 import suggestedContent from '../reducers/suggestedContentReducer';
 import externalAtom from '../reducers/externalAtomReducer';
 import queryParams from '../reducers/queryParamsReducer';
+import workflow from '../reducers/workflowReducer';
 import {routerReducer} from 'react-router-redux';
 
 export const rootReducer = combineReducers({
@@ -27,5 +28,6 @@ export const rootReducer = combineReducers({
   suggestedContent,
   externalAtom,
   queryParams,
+  workflow,
   routing: routerReducer
 });

--- a/public/js/reducers/workflowReducer.js
+++ b/public/js/reducers/workflowReducer.js
@@ -1,0 +1,10 @@
+export default function workflow(state={}, action) {
+
+  switch (action.type) {
+    case 'WORKFLOW_STATUS_GET_RECEIVE':
+      return action.status || state;
+
+    default:
+      return state;
+  }
+}

--- a/public/js/services/WorkflowApi.js
+++ b/public/js/services/WorkflowApi.js
@@ -29,11 +29,12 @@ export default {
         return data;
       }
 
+      const momentLaunchDate = moment(scheduledLaunchDate);
       return Object.assign({}, data, {
-        scheduledLaunchDate: moment(scheduledLaunchDate),
+        scheduledLaunchDate: moment(momentLaunchDate),
         note: `Launching ${momentLaunchDate.format("DD MMM YYYY HH:mm")}`
       });
-    }
+    };
 
     const workflowUrl = getWorkflowUrl();
     const payload = getWorkflowPayload(atom, section, scheduledLaunchDate, status);
@@ -49,7 +50,7 @@ export default {
           'Content-Type': 'application/json'
         }
       }
-    )
+    );
   },
 
   getSections() {
@@ -65,9 +66,8 @@ export default {
         cache: 'default'
       }
     ).then(response => {
-      return response.json()
+      return response.json();
     }).then(sections => {
-      const ordered = _.orderBy(sections.data, 'name');
       return _.orderBy(sections.data, 'name');
     });
   },
@@ -87,5 +87,23 @@ export default {
         ).then(response => {
           return response.json();
         });
+  },
+
+  getTrackableAtomTypes: () => {
+
+    const workflowUrl = getWorkflowUrl();
+
+    return pandaFetch(
+        `${workflowUrl}/api/allowedAtomTypes`,
+        {
+          method: 'get',
+          credentials: 'include',
+          mode: 'cors',
+          cache: 'default'
+        }
+        ).then(response => {
+          return response.json();
+        });
   }
-}
+
+};

--- a/public/js/services/WorkflowApi.js
+++ b/public/js/services/WorkflowApi.js
@@ -15,7 +15,7 @@ export default {
       const prodOffice = getProductionOffice();
 
       const data = {
-        contentType: atom.atomType,
+        contentType: _.camelCase(atom.atomType),
         editorId: atom.id,
         title: atom.title,
         priority: 0,

--- a/public/js/services/WorkflowApi.js
+++ b/public/js/services/WorkflowApi.js
@@ -1,0 +1,91 @@
+import { pandaFetch } from './pandaFetch';
+import {getStore} from '../util/storeAccessor';
+import _ from 'lodash';
+import getProductionOffice from '../util/getProductionOffice';
+import moment from 'moment';
+
+function getWorkflowUrl() { return getStore().getState().config.workflowUrl; }
+
+export default {
+
+  trackInWorkflow: (atom, section, scheduledLaunchDate, status) => {
+
+    const getWorkflowPayload = (atom, section, scheduledLaunchDate, status) => {
+
+      const prodOffice = getProductionOffice();
+
+      const data = {
+        contentType: atom.atomType,
+        editorId: atom.id,
+        title: atom.title,
+        priority: 0,
+        needsLegal: 'NA',
+        section: section,
+        status: status,
+        prodOffice: prodOffice,
+      };
+
+      if (!scheduledLaunchDate) {
+        return data;
+      }
+
+      return Object.assign({}, data, {
+        scheduledLaunchDate: moment(scheduledLaunchDate),
+        note: `Launching ${momentLaunchDate.format("DD MMM YYYY HH:mm")}`
+      });
+    }
+
+    const workflowUrl = getWorkflowUrl();
+    const payload = getWorkflowPayload(atom, section, scheduledLaunchDate, status);
+
+    return pandaFetch(
+      `${workflowUrl}/api/stubs`,
+      {
+        method: 'post',
+        credentials: 'include',
+        mode: 'cors',
+        body: JSON.stringify(payload),
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+  },
+
+  getSections() {
+
+    const workflowUrl = getWorkflowUrl();
+
+    return pandaFetch(
+      `${workflowUrl}/api/sections`,
+      {
+        method: 'get',
+        credentials: 'include',
+        mode: 'cors',
+        cache: 'default'
+      }
+    ).then(response => {
+      return response.json()
+    }).then(sections => {
+      const ordered = _.orderBy(sections.data, 'name');
+      return _.orderBy(sections.data, 'name');
+    });
+  },
+
+  getWorkflowStatus: (atom) => {
+
+    const workflowUrl = getWorkflowUrl();
+
+    return pandaFetch(
+        `${workflowUrl}/api/atom/${atom.id}`,
+        {
+          method: 'get',
+          credentials: 'include',
+          mode: 'cors',
+          cache: 'default'
+        }
+        ).then(response => {
+          return response.json();
+        });
+  }
+}

--- a/public/js/util/getProductionOffice.js
+++ b/public/js/util/getProductionOffice.js
@@ -1,0 +1,34 @@
+import moment from 'moment';
+
+function isBetween({value, lower, upper}) {
+  return value >= lower && value <= upper;
+}
+
+function getTimezoneOffset() {
+  const offset = moment().utcOffset();
+
+  if (isBetween({value: offset, lower: 480, upper: 660})) {
+    return 'SYD';
+  }
+
+  if (isBetween({value: offset, lower: -560, upper: -400})) {
+    return 'SFO';
+  }
+
+  if (isBetween({value: offset, lower: -400, upper: -240})) {
+    return 'NYC';
+  }
+
+  return 'LON';
+}
+
+export default function getProductionOffice() {
+  const timezoneProductionOfficeMap = {
+    SYD: 'AUS',
+    SFO: 'US',
+    NYC: 'US',
+    LON: 'UK'
+  };
+
+  return timezoneProductionOfficeMap[getTimezoneOffset()];
+}

--- a/public/styles/components/_workflow.scss
+++ b/public/styles/components/_workflow.scss
@@ -1,0 +1,18 @@
+.workflow__info {
+  font-size: 13px;
+  margin-bottom: 10px;
+
+  thead {
+    border-bottom: solid $color400Grey 1px;
+  }
+
+
+  td {
+    text-align: center;
+    padding-top: 5px;
+  }
+
+  td, th {
+    padding-right: 10px;
+  }
+}

--- a/public/styles/components/_workflow.scss
+++ b/public/styles/components/_workflow.scss
@@ -1,5 +1,5 @@
 .workflow__info {
-  font-size: 13px;
+  font-size: 11.5px;
   margin-bottom: 10px;
 
   thead {

--- a/public/styles/main.scss
+++ b/public/styles/main.scss
@@ -38,4 +38,5 @@
 'components/atom-editor',
 'components/atom-embed',
 'components/atom-actions',
-'components/targeting';
+'components/targeting',
+'components/workflow';


### PR DESCRIPTION
- Integrate workflow to atom workshop - similar to the support provided by media atom maker
- Allow for tracking supported atoms. 
- If atom type is unsupported, don't provide any workflow support.

![screen shot 2017-10-13 at 11 08 25](https://user-images.githubusercontent.com/3066534/31541599-1da8f210-b007-11e7-895f-4a6ee4af8975.png)
 from atom workshop and display their status if tracked in workflow
