### PR TITLE
Speed up suggestions page

### DIFF
--- a/public/js/actions/AtomActions/getSuggestionsForLatestContent.js
+++ b/public/js/actions/AtomActions/getSuggestionsForLatestContent.js
@@ -44,13 +44,20 @@ function getTargetUrls(tags) {
   });
 }
 
+const AllSnippets = ["guide","qanda","timeline","profile"];
+function isSnippet(atomType) {
+  return AllSnippets.indexOf(atomType.toLowerCase()) >= 0;
+}
+
 //Deduplicate the targeting urls across all content, and retrieve the atoms
 function getAtomUrlToAtom(contentArrayWithAtomUrls) {
   const atomUrls = distinct(flatten(contentArrayWithAtomUrls.map(item => item.atomUrls)));
 
   return Promise.all(atomUrls.map(getAtomFromTargetUrl)).then(atoms => {
     const atomUrlToAtom = {};
-    atoms.forEach(atom => atomUrlToAtom[atom.url] = atom);
+    atoms.forEach(atom => {
+      if (isSnippet(atom.atomType)) atomUrlToAtom[atom.url] = atom;
+    });
     return atomUrlToAtom;
   });
 }

--- a/public/js/services/TargetingApi.js
+++ b/public/js/services/TargetingApi.js
@@ -80,19 +80,3 @@ export const fetchTargetsForTags = (tags) => {
     }
   ).then(res => res.json());
 };
-
-export const fetchTargetsForTag = (tag) => {
-
-  const store = getStore();
-  const state = store.getState();
-  const targetingUrl = state.config.targetingUrl;
-
-  return pandaFetch(
-    `${targetingUrl}api/suggestions/search?tags=${tag}`,
-    {
-      method: 'get',
-      credentials: 'include',
-      mode: 'cors'
-    }
-  ).then(res => res.json());
-};


### PR DESCRIPTION
This page will only get suggestions for <= 20 articles, so it's generally quicker to send 1 query per article to the targeting api (rather than 1 per tag as before).