### PR TITLE
Flexible date formats for Timelines

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.0"
 scalaVersion := "2.11.8"
 
 lazy val awsVersion = "1.11.8"
-lazy val atomLibVersion = "1.1.10"
+lazy val atomLibVersion = "1.1.12"
 
 libraryDependencies ++= Seq(
   ws,

--- a/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
@@ -3,30 +3,74 @@ import {ManagedForm, ManagedField} from '../../../ManagedEditor';
 import FormFieldTextInput from '../../../FormFields/FormFieldTextInput';
 import FormFieldsScribeEditor from '../../../FormFields/FormFieldScribeEditor';
 import FormFieldDateTextInput from '../../../FormFields/FormFieldDateTextInput';
+import FormFieldRadioButtons from '../../../FormFields/FormFieldRadioButtons';
+import FormFieldCheckbox from "../../../FormFields/FormFieldCheckbox";
 
 export class TimelineItem extends React.Component {
   static propTypes = {
     fieldLabel: PropTypes.string,
     fieldName: PropTypes.string,
     fieldValue: PropTypes.shape({
-      title: PropTypes.string,
-      date: PropTypes.number,
-      body: PropTypes.string
+      title: PropTypes.string.isRequired,
+      date: PropTypes.number.isRequired,
+      toDate: PropTypes.number,
+      body: PropTypes.string,
+      dateFormat: PropTypes.string
     }),
     fieldPlaceholder: PropTypes.string,
     onUpdateField: PropTypes.func,
     onFormErrorsUpdate: PropTypes.func
   };
 
+    state = {
+        dateRangeRequired: typeof this.props.fieldValue === PropTypes.shape({
+            title: PropTypes.string,
+            date: PropTypes.number,
+            toDate: PropTypes.number,
+            body: PropTypes.string,
+            dateFormat: PropTypes.string
+        }),
+    };
+
+
+  dateFormats = [
+      {
+          value: 'day-month-year',
+          name: 'Calendar date e.g. Monday 13th July 2017'
+      },
+      {
+          value: 'month-year',
+          name: 'Month & year e.g. July 2017'
+      },
+      {
+          value: 'year',
+          name: 'Year e.g. 2017'
+      }
+  ]
+
+
   updateItem = (item) => {
-    this.props.onUpdateField(item);
+      this.props.onUpdateField(item);
   }
+
+  getDateFormat = () => {
+      const existingData = this.props.fieldValue || {};
+      return this.dateFormats.find(dateFormat => dateFormat.value === existingData.dateFormat);
+  }
+
+  updateDateRange = (dateRangeRequired) => {
+      this.setState({
+          dateRangeRequired: dateRangeRequired
+      });
+    };
+
 
   render () {
     const value = this.props.fieldValue || {
       title: " ",
       date: Date.now(),
-      body: " "
+      body: " ",
+      dateFormat: " "
     };
 
     return (
@@ -34,6 +78,18 @@ export class TimelineItem extends React.Component {
         <ManagedForm data={value} updateData={this.updateItem} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="timelineEditor">
           <ManagedField fieldLocation="date" name="Date" isRequired={true}>
             <FormFieldDateTextInput/>
+          </ManagedField>
+          <FormFieldCheckbox fieldName="ranged-date" fieldLabel="Want a date range?" fieldValue={this.state.dateRangeRequired} onUpdateField={this.updateDateRange.bind(this)}/>
+          <ManagedField isRequired={false} fieldLocation="toDate">
+            <FormFieldDateTextInput fieldName="ranged-date" disabled={!this.state.dateRangeRequired}/>
+          </ManagedField>
+          <ManagedField fieldLocation="dateFormat" name="Date Format" isRequired={false}>
+            <FormFieldRadioButtons
+                fieldLabel="Date Format"
+                selectValues={this.dateFormats.map(dateFormat => dateFormat.value)}
+                selectLabels={this.dateFormats.map(dateFormat => dateFormat.name)}
+                fieldValue={this.getDateFormat() ? this.getDateFormat().value : 'day-month-year'}
+                fieldCaption="will default to calendar date if left blank"/>
           </ManagedField>
           <ManagedField fieldLocation="title" name="Title" isRequired={true}>
             <FormFieldTextInput/>

--- a/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
@@ -3,7 +3,8 @@ import {ManagedForm, ManagedField} from '../../../ManagedEditor';
 import FormFieldTextInput from '../../../FormFields/FormFieldTextInput';
 import FormFieldsScribeEditor from '../../../FormFields/FormFieldScribeEditor';
 import FormFieldDateTextInput from '../../../FormFields/FormFieldDateTextInput';
-import FormFieldRadioButtons from '../../../FormFields/FormFieldRadioButtons';
+import FormFieldSelectBox from '../../../FormFields/FormFieldSelectBox';
+// import FormFieldRadioButtons from '../../../FormFields/FormFieldRadioButtons';
 import FormFieldCheckbox from "../../../FormFields/FormFieldCheckbox";
 
 export class TimelineItem extends React.Component {
@@ -33,7 +34,18 @@ export class TimelineItem extends React.Component {
     };
 
 
-  dateFormats = [
+       // TODO:
+       //  Remove the date format select option and replace with radio button lists
+       //  Remove ID in dateFormats array as will be superfluous
+       //
+       //  See this PR for further info: https://github.com/facebook/react/pull/11227
+       //
+       //  The radio button code has been left in for now as React devs are working on this bug.
+       //  React cannot handle multiple radio button lists and leaves only one button visibly checked
+       //  regardless of the props. This is only a bug of UX, and the data is being stored correctly
+       //  on the atom. We've chosen to release this feature with a select so to speed up delivery.
+
+dateFormats = [
       {
           value: 'day-month-year',
           name: 'Calendar date e.g. Monday 13th July 2017'
@@ -48,15 +60,14 @@ export class TimelineItem extends React.Component {
       }
   ]
 
-
   updateItem = (item) => {
       this.props.onUpdateField(item);
   }
 
-  getDateFormat = () => {
-      const existingData = this.props.fieldValue || {};
-      return this.dateFormats.find(dateFormat => dateFormat.value === existingData.dateFormat);
-  }
+  // getDateFormat = () => {
+  //     const existingData = this.props.fieldValue || {};
+  //     return this.dateFormats.find(dateFormat => dateFormat.value === existingData.dateFormat);
+  // }
 
   updateDateRange = (dateRangeRequired) => {
       this.setState({
@@ -83,13 +94,20 @@ export class TimelineItem extends React.Component {
           <ManagedField isRequired={false} fieldLocation="toDate">
             <FormFieldDateTextInput fieldName="ranged-date" disabled={!this.state.dateRangeRequired}/>
           </ManagedField>
-          <ManagedField fieldLocation="dateFormat" name="Date Format" isRequired={false}>
-            <FormFieldRadioButtons
+          <ManagedField fieldLocation="date-format" name="Date Format" isRequired={false}>
+            <FormFieldSelectBox
                 fieldLabel="Date Format"
-                selectValues={this.dateFormats.map(dateFormat => dateFormat.value)}
-                selectLabels={this.dateFormats.map(dateFormat => dateFormat.name)}
-                fieldValue={this.getDateFormat() ? this.getDateFormat().value : 'day-month-year'}
-                fieldCaption="will default to calendar date if left blank"/>
+                selectValues={this.dateFormats}
+                displayEmptyOptions={true}
+            />
+
+            {/*<FormFieldRadioButtons*/}
+                {/*fieldLabel="Date Format"*/}
+                {/*selectValues={this.dateFormats.map(dateFormat => dateFormat.value)}*/}
+                {/*selectLabels={this.dateFormats.map(dateFormat => dateFormat.name)}*/}
+                {/*fieldValue={this.getDateFormat() ? this.getDateFormat().value : 'day-month-year'}*/}
+                {/*fieldCaption="will default to calendar date if left blank"/>*/}
+
           </ManagedField>
           <ManagedField fieldLocation="title" name="Title" isRequired={true}>
             <FormFieldTextInput/>

--- a/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
@@ -81,7 +81,7 @@ dateFormats = [
       title: " ",
       date: Date.now(),
       body: " ",
-      dateFormat: " "
+      dateFormat: "day-month-year"
     };
 
     return (
@@ -94,11 +94,11 @@ dateFormats = [
           <ManagedField isRequired={false} fieldLocation="toDate">
             <FormFieldDateTextInput fieldName="ranged-date" disabled={!this.state.dateRangeRequired}/>
           </ManagedField>
-          <ManagedField fieldLocation="date-format" name="Date Format" isRequired={false}>
+          <ManagedField fieldLocation="dateFormat" name="Date Format" isRequired={false}>
             <FormFieldSelectBox
                 fieldLabel="Date Format"
                 selectValues={this.dateFormats}
-                displayEmptyOptions={true}
+                optionsAsObject={false}
             />
 
             {/*<FormFieldRadioButtons*/}

--- a/public/js/components/FormFields/FormFieldCheckbox.js
+++ b/public/js/components/FormFields/FormFieldCheckbox.js
@@ -18,7 +18,7 @@ export default class FormFieldCheckbox extends React.Component {
 
   render() {
     return (
-      <div className="form__ group form__group--checkbox">
+      <div className={'form__ group form__group--checkbox--' + this.props.fieldName}>
         {this.props.fieldLabel ? <label className="form__label" htmlFor={this.props.fieldName}>{this.props.fieldLabel}</label> : false}
         <input className="form__checkbox" type="checkbox" checked={this.props.fieldValue} name={this.props.fieldName} value={this.props.fieldValue} onChange={this.onUpdate} />
         {!this.props.fieldLabel ? <span className="form__label form__label--checkbox">{this.props.fieldName}</span> : false}

--- a/public/js/components/FormFields/FormFieldDateTextInput.js
+++ b/public/js/components/FormFields/FormFieldDateTextInput.js
@@ -5,14 +5,14 @@ import moment from 'moment';
 
 export default class FormFieldDateTextInput extends React.Component {
 
-
     static propTypes = {
         fieldLabel: PropTypes.string,
         fieldName: PropTypes.string,
         fieldValue: PropTypes.number,
         fieldErrors: PropTypes.arrayOf(errorPropType),
         formRowClass: PropTypes.string,
-        onUpdateField: PropTypes.func
+        onUpdateField: PropTypes.func,
+        disabled: PropTypes.bool
     };
 
     millisecondsToString = (ms) => moment.utc(ms).format("YYYY-MM-DD");
@@ -41,6 +41,7 @@ export default class FormFieldDateTextInput extends React.Component {
                     id={this.props.fieldName}
                     onChange={this.onUpdate}
                     value={this.state.fieldDisplayValue || ""}
+                    disabled={this.props.disabled}
                 />
                 <ShowErrors errors={this.props.fieldErrors}/>
             </div>

--- a/public/js/components/FormFields/FormFieldRadioButtons.js
+++ b/public/js/components/FormFields/FormFieldRadioButtons.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react';
 import ShowErrors from '../Utilities/ShowErrors';
 import { errorPropType } from '../../constants/errorPropType';
-import uuidv4 from 'uuid/v4';
+
 
 export default class FormFieldRadioButtons extends React.Component {
 
@@ -23,8 +23,8 @@ export default class FormFieldRadioButtons extends React.Component {
 
   renderButton(value, label, i) {
     return (
-      <div key={i+uuidv4()} className="form__group--radio">
-        <input key={uuidv4()} className="form__radio-btn" type="radio" value={value} checked={this.props.fieldValue === value ? 'checked' : false} onChange={this.onUpdate} name={this.props.fieldName} />
+      <div key={i} className="form__group--radio">
+        <input className="form__radio-btn" type="radio" value={value} checked={this.props.fieldValue === value ? 'checked' : false} onChange={this.onUpdate} name={this.props.fieldName} />
         <span className="form__label form__label--radio">{label}</span>
       </div>
     );

--- a/public/js/components/FormFields/FormFieldRadioButtons.js
+++ b/public/js/components/FormFields/FormFieldRadioButtons.js
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react';
 import ShowErrors from '../Utilities/ShowErrors';
 import { errorPropType } from '../../constants/errorPropType';
+import uuidv4 from 'uuid/v4';
 
 export default class FormFieldRadioButtons extends React.Component {
 
@@ -22,8 +23,8 @@ export default class FormFieldRadioButtons extends React.Component {
 
   renderButton(value, label, i) {
     return (
-      <div key={i} className="form__group--radio">
-        <input className="form__radio-btn" type="radio" name={this.props.fieldName} value={value} checked={this.props.fieldValue === value ? 'checked' : false} onChange={this.onUpdate} />
+      <div key={i+uuidv4()} className="form__group--radio">
+        <input key={uuidv4()} className="form__radio-btn" type="radio" value={value} checked={this.props.fieldValue === value ? 'checked' : false} onChange={this.onUpdate} name={this.props.fieldName} />
         <span className="form__label form__label--radio">{label}</span>
       </div>
     );

--- a/public/js/components/FormFields/FormFieldRadioButtons.js
+++ b/public/js/components/FormFields/FormFieldRadioButtons.js
@@ -8,33 +8,43 @@ export default class FormFieldRadioButtons extends React.Component {
     fieldLabel: PropTypes.string,
     fieldName: PropTypes.string,
     selectValues: PropTypes.arrayOf(PropTypes.string),
+    selectLabels: PropTypes.arrayOf(PropTypes.string),
     fieldValue: PropTypes.string,
     fieldErrors: PropTypes.arrayOf(errorPropType),
     formRowClass: PropTypes.string,
-    onUpdateField: PropTypes.func
+    onUpdateField: PropTypes.func,
+    fieldCaption: PropTypes.string
   };
 
   onUpdate = (e) => {
     this.props.onUpdateField(e.target.value);
   }
 
-  renderButton(value, i) {
+  renderButton(value, label, i) {
     return (
       <div key={i} className="form__group--radio">
         <input className="form__radio-btn" type="radio" name={this.props.fieldName} value={value} checked={this.props.fieldValue === value ? 'checked' : false} onChange={this.onUpdate} />
-        <span className="form__label form__label--radio">{value}</span>
+        <span className="form__label form__label--radio">{label}</span>
       </div>
     );
   }
 
   renderButtons() {
-    return this.props.selectValues.map(this.renderButton, this);
+    return this.props.selectValues.map(function(value, index) {
+      return this.renderButton(value, this.props.selectLabels ? this.props.selectLabels[index] : value, index);
+    }, this);
   }
 
   render() {
+
     return (
         <div className={this.props.formRowClass || "form__row"}>
-          {this.props.fieldLabel ? <label htmlFor={this.props.fieldName} className="form__label">{this.props.fieldLabel}</label> : false}
+          {this.props.fieldLabel ?
+              <label htmlFor={this.props.fieldName} className="form__label">
+                {this.props.fieldLabel}
+                {this.props.fieldCaption ? <small className="form__label--caption">{this.props.fieldCaption}</small> : false}
+              </label>
+              : false}
           {this.renderButtons()}
           <ShowErrors errors={this.props.fieldErrors}/>
         </div>

--- a/public/js/components/FormFields/FormFieldSelectBox.js
+++ b/public/js/components/FormFields/FormFieldSelectBox.js
@@ -23,6 +23,12 @@ export default class FormFieldSelectBox extends React.Component {
       );
     }
 
+    if (option.name) {
+        return (
+            <option key={option.name} value={option.value}>{option.name}</option>
+        );
+    }
+
     return (
       <option key={option} value={option}>{option}</option>
     );

--- a/public/js/components/FormFields/__snapshots__/FormFieldCheckbox.spec.js.snap
+++ b/public/js/components/FormFields/__snapshots__/FormFieldCheckbox.spec.js.snap
@@ -1,6 +1,6 @@
 exports[`test Should render 1`] = `
 <div
-  className="form__ group form__group--checkbox">
+  className="form__ group form__group--checkbox--test">
   <label
     className="form__label"
     htmlFor="test">

--- a/public/js/components/FormFields/__snapshots__/FormFieldCheckboxGroup.spec.js.snap
+++ b/public/js/components/FormFields/__snapshots__/FormFieldCheckboxGroup.spec.js.snap
@@ -7,7 +7,7 @@ exports[`test Should render 1`] = `
     test
   </label>
   <div
-    className="form__ group form__group--checkbox">
+    className="form__ group form__group--checkbox--one">
     <input
       checked={true}
       className="form__checkbox"
@@ -21,7 +21,7 @@ exports[`test Should render 1`] = `
     </span>
   </div>
   <div
-    className="form__ group form__group--checkbox">
+    className="form__ group form__group--checkbox--two">
     <input
       checked={true}
       className="form__checkbox"
@@ -35,7 +35,7 @@ exports[`test Should render 1`] = `
     </span>
   </div>
   <div
-    className="form__ group form__group--checkbox">
+    className="form__ group form__group--checkbox--three">
     <input
       checked={false}
       className="form__checkbox"

--- a/public/js/components/ManagedEditor/ManagedEditorField.js
+++ b/public/js/components/ManagedEditor/ManagedEditorField.js
@@ -20,6 +20,7 @@ export class ManagedField extends React.Component {
     updateFormErrors: PropTypes.func,
     data: PropTypes.object,
     name: PropTypes.string,
+    label: PropTypes.string,
     isRequired: PropTypes.bool,
     customValidation: PropTypes.arrayOf(PropTypes.func)
   };
@@ -51,7 +52,7 @@ export class ManagedField extends React.Component {
     const hydratedChildren = React.Children.map(this.props.children, (child) => {
       return React.cloneElement(child, {
         fieldName: this.props.name,
-        fieldLabel: this.props.name,
+        fieldLabel: this.props.label ? this.props.label : this.props.name,
         fieldValue: _get(this.props.fieldLocation, this.props.data),
         fieldErrors: this.state.touched ? this.state.fieldErrors : undefined,
         onUpdateField: this.updateFn,

--- a/public/styles/components/_forms.scss
+++ b/public/styles/components/_forms.scss
@@ -72,6 +72,11 @@
   &--nested {
     border: none;
   }
+
+  input[disabled] {
+    background-color: #D3D3D3;
+    color: #565a5c;
+  }
 }
 
 .form__field--multiselect {
@@ -150,6 +155,12 @@
 
   &--checkbox {
     border: none;
+
+    &--ranged-date {
+      display: flex;
+      justify-content: space-between;
+    }
+
   }
 
   &--flex {
@@ -187,6 +198,11 @@
   &--radio, &--checkbox {
     display: inline-block;
     margin: 0;
+    font-weight: normal;
+  }
+
+  &--caption {
+    display: block;
     font-weight: normal;
   }
 }


### PR DESCRIPTION
Allow users to select relevant date format for events and date ranges if required.

Tested on `CODE`


![screen shot 2017-11-15 at 11 42 59](https://user-images.githubusercontent.com/14946184/32834333-29fe6452-c9fa-11e7-90f3-a0fc9b46912f.png)
