### PR TITLE
Set word limit on Snippets

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/GuideEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/GuideEditor.js
@@ -4,6 +4,7 @@ import FormFieldArrayWrapper from '../../FormFields/FormFieldArrayWrapper';
 import {GuideItem} from './GuideFields/GuideItem';
 import {ManagedField, ManagedForm} from '../../ManagedEditor';
 import {atomPropType} from '../../../constants/atomPropType';
+import {checkItemsUnderWordCount} from '../../../util/validators';
 
 export class GuideEditor extends React.Component {
 
@@ -23,7 +24,7 @@ export class GuideEditor extends React.Component {
           <ManagedField fieldLocation="data.guide.guideImage" name="Guide Image">
             <FormFieldImageSelect gridUrl={this.props.config.gridUrl}/>
           </ManagedField>
-          <ManagedField fieldLocation="data.guide.items" name="Items">
+          <ManagedField fieldLocation="data.guide.items" name="Items" customValidation={[checkItemsUnderWordCount]}>
             <FormFieldArrayWrapper>
               <GuideItem onFormErrorsUpdate={this.props.onFormErrorsUpdate} />
             </FormFieldArrayWrapper>

--- a/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
@@ -35,7 +35,7 @@ export class GuideItem extends React.Component {
             <FormFieldTextInput/>
           </ManagedField>
           <ManagedField fieldLocation="body" name="Body" isRequired={true}>
-            <FormFieldsScribeEditor showWordCount={true} suggestedLength={150} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"}/>
+            <FormFieldsScribeEditor showWordCount={true} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"}/>
           </ManagedField>
         </ManagedForm>
         <ShowErrors errors={this.props.fieldErrors}/>

--- a/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
@@ -2,10 +2,13 @@ import React, { PropTypes } from 'react';
 import {ManagedForm, ManagedField} from '../../../ManagedEditor';
 import FormFieldTextInput from '../../../FormFields/FormFieldTextInput';
 import FormFieldsScribeEditor from '../../../FormFields/FormFieldScribeEditor';
+import ShowErrors from '../../../Utilities/ShowErrors';
+import { errorPropType } from '../../../../constants/errorPropType';
 
 export class GuideItem extends React.Component {
   static propTypes = {
     fieldLabel: PropTypes.string,
+    fieldErrors: PropTypes.arrayOf(errorPropType),
     fieldName: PropTypes.string,
     fieldValue: PropTypes.shape({
       title: PropTypes.string,
@@ -35,6 +38,7 @@ export class GuideItem extends React.Component {
             <FormFieldsScribeEditor showWordCount={true} suggestedLength={150} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"}/>
           </ManagedField>
         </ManagedForm>
+        <ShowErrors errors={this.props.fieldErrors}/>
       </div>
     );
   }

--- a/public/js/components/AtomEdit/CustomEditors/ProfileEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/ProfileEditor.js
@@ -4,7 +4,7 @@ import FormFieldArrayWrapper from '../../FormFields/FormFieldArrayWrapper';
 import {ProfileItem} from './ProfileFields/ProfileItem';
 import {ManagedField, ManagedForm} from '../../ManagedEditor';
 import {atomPropType} from '../../../constants/atomPropType';
-
+import {checkItemsUnderWordCount} from '../../../util/validators';
 
 export class ProfileEditor extends React.Component {
 
@@ -24,7 +24,7 @@ export class ProfileEditor extends React.Component {
           <ManagedField fieldLocation="data.profile.headshot" name="Head shot">
             <FormFieldImageSelect gridUrl={this.props.config.gridUrl}/>
           </ManagedField>
-          <ManagedField fieldLocation="data.profile.items" name="Items">
+          <ManagedField fieldLocation="data.profile.items" name="Items" customValidation={[checkItemsUnderWordCount]}>
             <FormFieldArrayWrapper>
               <ProfileItem onFormErrorsUpdate={this.props.onFormErrorsUpdate} />
             </FormFieldArrayWrapper>

--- a/public/js/components/AtomEdit/CustomEditors/ProfileFields/ProfileItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/ProfileFields/ProfileItem.js
@@ -2,10 +2,13 @@ import React, { PropTypes } from 'react';
 import {ManagedForm, ManagedField} from '../../../ManagedEditor';
 import FormFieldTextInput from '../../../FormFields/FormFieldTextInput';
 import FormFieldsScribeEditor from '../../../FormFields/FormFieldScribeEditor';
+import ShowErrors from '../../../Utilities/ShowErrors';
+import { errorPropType } from '../../../../constants/errorPropType';
 
 export class ProfileItem extends React.Component {
   static propTypes = {
     fieldLabel: PropTypes.string,
+    fieldErrors: PropTypes.arrayOf(errorPropType),
     fieldName: PropTypes.string,
     fieldValue: PropTypes.shape({
       title: PropTypes.string,
@@ -35,6 +38,7 @@ export class ProfileItem extends React.Component {
             <FormFieldsScribeEditor showWordCount={true} suggestedLength={150} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"} />
           </ManagedField>
         </ManagedForm>
+        <ShowErrors errors={this.props.fieldErrors}/>
       </div>
     );
   }

--- a/public/js/components/AtomEdit/CustomEditors/ProfileFields/ProfileItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/ProfileFields/ProfileItem.js
@@ -35,7 +35,7 @@ export class ProfileItem extends React.Component {
             <FormFieldTextInput/>
           </ManagedField>
           <ManagedField fieldLocation="body" name="Body" isRequired={true}>
-            <FormFieldsScribeEditor showWordCount={true} suggestedLength={150} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"} />
+            <FormFieldsScribeEditor showWordCount={true} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"} />
           </ManagedField>
         </ManagedForm>
         <ShowErrors errors={this.props.fieldErrors}/>

--- a/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
@@ -2,6 +2,8 @@ import React, { PropTypes } from 'react';
 import {ManagedForm, ManagedField} from '../../../ManagedEditor';
 import FormFieldsScribeEditor from '../../../FormFields/FormFieldScribeEditor';
 
+const WordLimit = 250;
+
 export class QAItem extends React.Component {
   static propTypes = {
     fieldLabel: PropTypes.string,
@@ -29,7 +31,7 @@ export class QAItem extends React.Component {
       <div className="form__field">
         <ManagedForm data={value} updateData={this.updateItem} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="qaEditor">
           <ManagedField fieldLocation="body" name="Answer" isRequired={true}>
-            <FormFieldsScribeEditor showWordCount={true} suggestedLength={250} showToolbar={false} tooLongMsg={"You've exceed the word limit of 250 for this atom."}/>
+            <FormFieldsScribeEditor showWordCount={true} suggestedLength={WordLimit} showToolbar={false} tooLongMsg={`You've exceeded the ${WordLimit} word limit for this atom.`}/>
           </ManagedField>
         </ManagedForm>
       </div>

--- a/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
@@ -29,7 +29,7 @@ export class QAItem extends React.Component {
       <div className="form__field">
         <ManagedForm data={value} updateData={this.updateItem} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="qaEditor">
           <ManagedField fieldLocation="body" name="Answer" isRequired={true}>
-            <FormFieldsScribeEditor showWordCount={true} suggestedLength={150} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"}/>
+            <FormFieldsScribeEditor showWordCount={true} suggestedLength={250} showToolbar={false} tooLongMsg={"You've exceed the word limit of 250 for this atom."}/>
           </ManagedField>
         </ManagedForm>
       </div>

--- a/public/js/components/AtomEdit/CustomEditors/TimelineEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/TimelineEditor.js
@@ -4,7 +4,7 @@ import {TimelineItem} from './TimelineFields/TimelineItem';
 import {ManagedField, ManagedForm} from '../../ManagedEditor';
 import {atomPropType} from '../../../constants/atomPropType';
 import FormFieldsScribeEditor from '../../FormFields/FormFieldScribeEditor';
-
+import {checkItemsUnderWordCount} from '../../../util/validators';
 
 export class TimelineEditor extends React.Component {
 
@@ -22,7 +22,7 @@ export class TimelineEditor extends React.Component {
           <ManagedField fieldLocation="data.timeline.description" name="Description - optional" isRequired={false}>
             <FormFieldsScribeEditor showWordCount={true} suggestedLength={50} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"}/>
           </ManagedField>
-          <ManagedField fieldLocation="data.timeline.events" name="Events">
+          <ManagedField fieldLocation="data.timeline.events" name="Events" customValidation={[checkItemsUnderWordCount]}>
             <FormFieldArrayWrapper>
               <TimelineItem onFormErrorsUpdate={this.props.onFormErrorsUpdate}/>
             </FormFieldArrayWrapper>

--- a/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
@@ -122,7 +122,7 @@ dateFormats = [
             <FormFieldTextInput/>
           </ManagedField>
           <ManagedField fieldLocation="body" name="Body">
-            <FormFieldsScribeEditor showWordCount={true} suggestedLength={150} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"}/>
+            <FormFieldsScribeEditor showWordCount={true} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"}/>
           </ManagedField>
         </ManagedForm>
           <ShowErrors errors={this.props.fieldErrors}/>

--- a/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
@@ -6,10 +6,13 @@ import FormFieldDateTextInput from '../../../FormFields/FormFieldDateTextInput';
 import FormFieldSelectBox from '../../../FormFields/FormFieldSelectBox';
 // import FormFieldRadioButtons from '../../../FormFields/FormFieldRadioButtons';
 import FormFieldCheckbox from "../../../FormFields/FormFieldCheckbox";
+import ShowErrors from '../../../Utilities/ShowErrors';
+import { errorPropType } from '../../../../constants/errorPropType';
 
 export class TimelineItem extends React.Component {
   static propTypes = {
     fieldLabel: PropTypes.string,
+    fieldErrors: PropTypes.arrayOf(errorPropType),
     fieldName: PropTypes.string,
     fieldValue: PropTypes.shape({
       title: PropTypes.string.isRequired,
@@ -122,6 +125,7 @@ dateFormats = [
             <FormFieldsScribeEditor showWordCount={true} suggestedLength={150} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"}/>
           </ManagedField>
         </ManagedForm>
+          <ShowErrors errors={this.props.fieldErrors}/>
       </div>
     );
   }

--- a/public/js/components/FormFields/FormFieldArrayWrapper.js
+++ b/public/js/components/FormFields/FormFieldArrayWrapper.js
@@ -86,7 +86,7 @@ export default class FormFieldArrayWrapper extends React.Component {
   }
 
   render () {
-    const values = (this.props.fieldValue || []).concat(this.state.newItems);
+   const values = (this.props.fieldValue || []).concat(this.state.newItems);
 
     return (
       <div className={this.props.nested ? 'form__row form__row--nested' : 'form__row'}>

--- a/public/js/util/validators.js
+++ b/public/js/util/validators.js
@@ -15,3 +15,28 @@ export const isHttpsUrl = (value) => {
     return Promise.resolve(error);
   }
 };
+
+export const checkItemsUnderWordCount = (values) => {
+    if (values.length > 0) {
+        var wordCountList = values.map(function(itemData) {
+            return stripHtml(itemData.body).length;
+        });
+
+        var totalCount = wordCountList.reduce(function (total, num) {
+            return total + num;
+        });
+
+        if (totalCount <= 400) {
+            return Promise.resolve(true);
+        } else {
+            const error = new FieldError('too-long', 'You\'ve reached the word limit on this atom type');
+            return Promise.resolve(error);
+        }
+
+    }
+};
+
+function stripHtml(rawBody) {
+  return rawBody.replace(/<{1}[^<>]{1,}>{1}/g,"");
+}
+

--- a/public/js/util/validators.js
+++ b/public/js/util/validators.js
@@ -18,18 +18,19 @@ export const isHttpsUrl = (value) => {
 
 export const checkItemsUnderWordCount = (values) => {
     if (values.length > 0) {
-        var wordCountList = values.map(function(itemData) {
-            return stripHtml(itemData.body).length;
+        var wordCount = values.map(function(itemData) {
+            var strippedText = stripHtml(itemData.body);
+            return strippedText.split(" ").length;
         });
 
-        var totalCount = wordCountList.reduce(function (total, num) {
+        var totalCount = wordCount.reduce(function (total, num) {
             return total + num;
         });
 
         if (totalCount <= 400) {
             return Promise.resolve(true);
         } else {
-            const error = new FieldError('too-long', 'You\'ve reached the word limit on this atom type');
+            const error = new FieldError('too-long', 'You\'ve reached the word limit on this atom type. Please edit your items to less than a total of 400 words.');
             return Promise.resolve(error);
         }
 

--- a/public/js/util/validators.js
+++ b/public/js/util/validators.js
@@ -16,6 +16,7 @@ export const isHttpsUrl = (value) => {
   }
 };
 
+const WordLimit = 400;
 export const checkItemsUnderWordCount = (values) => {
     if (values.length > 0) {
         var wordCount = values.map(function(itemData) {
@@ -27,10 +28,10 @@ export const checkItemsUnderWordCount = (values) => {
             return total + num;
         });
 
-        if (totalCount <= 400) {
+        if (totalCount <= WordLimit) {
             return Promise.resolve(true);
         } else {
-            const error = new FieldError('too-long', 'You\'ve reached the word limit on this atom type. Please edit your items to less than a total of 400 words.');
+            const error = new FieldError('too-long', `You\'ve reached the word limit on this atom type. Please edit your items to less than a total of ${WordLimit} words.`);
             return Promise.resolve(error);
         }
 


### PR DESCRIPTION
This sets a word limit on Q&As of 250 words, and on Guides, Timelines & Profiles of 400 words across multiple blocks within the atom.