### PR TITLE
Allow removal of toDate on timelines

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
@@ -67,6 +67,16 @@ export class TimelineItem extends React.Component {
     this.setState({
       dateRangeRequired: dateRangeRequired
     });
+
+    //Remove the toDate if no longer set
+    const updated = Object.assign({}, this.props.fieldValue, {
+      title: this.props.fieldValue.title,
+      date: this.props.fieldValue.date,
+      toDate: dateRangeRequired ? this.props.fieldValue.toDate : null,
+      body: this.props.fieldValue.body,
+      dateFormat: this.props.fieldValue.dateFormat
+    });
+    this.props.onUpdateField(updated);
   };
 
   renderDateRangeSelector = () => {

--- a/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
@@ -70,11 +70,7 @@ export class TimelineItem extends React.Component {
 
     //Remove the toDate if no longer set
     const updated = Object.assign({}, this.props.fieldValue, {
-      title: this.props.fieldValue.title,
-      date: this.props.fieldValue.date,
-      toDate: dateRangeRequired ? this.props.fieldValue.toDate : null,
-      body: this.props.fieldValue.body,
-      dateFormat: this.props.fieldValue.dateFormat
+      toDate: dateRangeRequired ? this.props.fieldValue.toDate : null
     });
     this.props.onUpdateField(updated);
   };


### PR DESCRIPTION
Currently you can't remove a date range once you've set it.

There must be a nicer way of doing this...