### PR TITLE
use signature version 4 to authenticate requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ for the composer AWS account from [janus](https://janus.gutools.co.uk). You'll a
 'Install SSL certificates' step in the [dev-nginx readme](https://github.com/guardian/dev-nginx). Then:
 
  - Fetch config from S3: `./fetch-config.sh`
+ - If you get an error message saying that you requred AWS Signature Version 4, configure your aws cli by running `aws configure set default.s3.signature_version s3v4`
  - Setup the nginx mapping by following the instructions in the
  [dev-nginx readme](https://github.com/guardian/dev-nginx#install-config-for-an-application).
  - Install Client Side Dependencies with `./scripts/setup.sh`

--- a/fetch-config.sh
+++ b/fetch-config.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+region="eu-west-1"
+
 mkdir -p ~/.configuration-magic/
-aws s3 cp s3://guconf-flexible/atom-workshop/atom-workshop.conf ~/.configuration-magic/atom-workshop.conf --profile composer
+aws s3 cp s3://guconf-flexible/atom-workshop/atom-workshop.conf ~/.configuration-magic/atom-workshop.conf --profile composer --region $region


### PR DESCRIPTION
So that we can fetch configs from encrypted buckets.