### PR TITLE
Use atom renderer for default html for reader questions and snippets

### DIFF
--- a/app/util/AtomElementBuilders.scala
+++ b/app/util/AtomElementBuilders.scala
@@ -66,7 +66,7 @@ object AtomElementBuilders {
     )
   }
 
-  def buildDefaultHtml(atom: Atom): Option[String] = atom.atomData match {
+  def buildDefaultHtml(atom: Atom): Option[String] = atom.data match {
     case x: AtomData.Storyquestions if isOpen(x.storyquestions) => DefaultAtomRenderer.getHTML(atom)
     case x: AtomData.Storyquestions => Some("")
     case x: AtomData.Guide          => DefaultAtomRenderer.getHTML(atom)

--- a/app/util/AtomElementBuilders.scala
+++ b/app/util/AtomElementBuilders.scala
@@ -1,5 +1,6 @@
 package util
 
+import com.gu.contentatom.renderer.DefaultAtomRenderer
 import com.gu.contentatom.thrift.atom.cta.CTAAtom
 import com.gu.contentatom.thrift.atom.recipe.{RecipeAtom, Tags => RecipeTags, Time => RecipeTime}
 import com.gu.contentatom.thrift.atom.storyquestions.{RelatedStoryLinkType, StoryQuestionsAtom}
@@ -10,7 +11,7 @@ import com.gu.contentatom.thrift.atom.timeline.TimelineAtom
 import com.gu.contentatom.thrift.{User, _}
 import com.gu.pandomainauth.model.{User => PandaUser}
 import models.CreateAtomFields
-import org.joda.time.DateTime
+import org.joda.time.{ DateTime, DateTimeZone }
 import org.joda.time.format.DateTimeFormat
 
 object AtomElementBuilders {
@@ -47,65 +48,36 @@ object AtomElementBuilders {
       AtomType.Timeline -> AtomData.Timeline(TimelineAtom())
     )
 
-    Atom(
+    val atom = Atom(
       title = createAtomFields.flatMap(_.title),
       commissioningDesks = createAtomFields.map(_.commissioningDesks).getOrElse(Nil),
       id = java.util.UUID.randomUUID.toString,
       atomType = atomType,
-      defaultHtml = createAtomFields.flatMap(_.defaultHtml).getOrElse(buildDefaultHtml(atomType = atomType, atomData = defaultAtoms(atomType))),
+      defaultHtml = "",
       data = defaultAtoms(atomType),
       contentChangeDetails = buildContentChangeDetails(user, None, updateCreated = true)
     )
+
+    atom.copy(
+      defaultHtml = createAtomFields
+        .flatMap(_.defaultHtml)
+        .orElse(buildDefaultHtml(atom))
+        .getOrElse("")
+    )
   }
 
-  def buildDefaultHtml(atomType: AtomType, atomData: AtomData): String = {
-    s"""<div class="atom-${atomType.name}">${buildHtml(atomType, atomData).getOrElse("")}</div>"""
-  }
-
-  def buildHtml(atomType: AtomType, atomData: AtomData): Option[String] = atomData match {
-    case x: AtomData.Storyquestions => buildStoryQuestionsHtml(x.storyquestions)
-    case x: AtomData.Guide          => buildGuideHtml(x.guide)
-    case x: AtomData.Profile        => buildProfileHtml(x.profile)
-    case x: AtomData.Qanda          => buildQAndAHtml(x.qanda)
-    case x: AtomData.Timeline       => buildTimelineHtml(x.timeline)
+  def buildDefaultHtml(atom: Atom): Option[String] = atom.atomData match {
+    case x: AtomData.Storyquestions if isOpen(x.storyquestions) => DefaultAtomRenderer.getHTML(atom)
+    case x: AtomData.Storyquestions => Some("")
+    case x: AtomData.Guide          => DefaultAtomRenderer.getHTML(atom)
+    case x: AtomData.Profile        => DefaultAtomRenderer.getHTML(atom)
+    case x: AtomData.Qanda          => DefaultAtomRenderer.getHTML(atom)
+    case x: AtomData.Timeline       => DefaultAtomRenderer.getHTML(atom)
     case _ => None
   }
 
-  def buildStoryQuestionsHtml(storyquestions: StoryQuestionsAtom): Option[String] = for {
-    eqs <- storyquestions.editorialQuestions
-  } yield {
-    val list = eqs flatMap (_.questions map { q => s"<li>${q.questionText}</li>" }) mkString ""
-    "<ul>" ++ list ++ "</ul>"
-  }
-
-  def buildGuideHtml(atom: GuideAtom): Option[String] =
-    Some(
-      atom.items.map{ item =>
-        item.title.map(title => s"<p><strong>$title</strong></p>").getOrElse("") ++
-        s"<p>${item.body}</p>"
-      }.mkString("")
-    )
-
-  def buildProfileHtml(atom: ProfileAtom): Option[String] =
-    Some(
-      atom.items.map{ item =>
-        item.title.map(title => s"<p><strong>$title</strong></p>").getOrElse("") ++
-        s"<p>${item.body}</p>"
-      }.mkString("")
-    )
-
-  def buildQAndAHtml(atom: QAndAAtom): Option[String] =
-    Some(atom.item).map { item =>
-      item.title.map(title => s"<p><strong>$title</strong></p>").getOrElse("") ++
-      s"<p>${item.body}</p>"
+  val isOpen: StoryQuestionsAtom => Boolean =
+    !_.closeDate.exists { closeDate =>
+      closeDate < DateTime.now(DateTimeZone.UTC).getMillis
     }
-
-  def buildTimelineHtml(atom: TimelineAtom): Option[String] =
-    Some(
-      atom.events.map{ item =>
-        val date = new DateTime(item.date)
-        s"<p><i>(${DateTimeFormat.longDate.print(date)})</i>&nbsp;<strong>${item.title}</strong></p>" ++
-        item.body.map(body => s"<p>${body}</p>").getOrElse("")
-      }.mkString("")
-    )
 }

--- a/app/util/AtomElementBuilders.scala
+++ b/app/util/AtomElementBuilders.scala
@@ -61,19 +61,17 @@ object AtomElementBuilders {
     atom.copy(
       defaultHtml = createAtomFields
         .flatMap(_.defaultHtml)
-        .orElse(buildDefaultHtml(atom))
-        .getOrElse("")
+        .getOrElse(buildDefaultHtml(atom))
     )
   }
 
-  def buildDefaultHtml(atom: Atom): Option[String] = atom.data match {
+  def buildDefaultHtml(atom: Atom): String = atom.data match {
     case x: AtomData.Storyquestions if isOpen(x.storyquestions) => DefaultAtomRenderer.getHTML(atom)
-    case x: AtomData.Storyquestions => Some("")
+    case x: AtomData.Storyquestions => ""
     case x: AtomData.Guide          => DefaultAtomRenderer.getHTML(atom)
     case x: AtomData.Profile        => DefaultAtomRenderer.getHTML(atom)
     case x: AtomData.Qanda          => DefaultAtomRenderer.getHTML(atom)
     case x: AtomData.Timeline       => DefaultAtomRenderer.getHTML(atom)
-    case _ => None
   }
 
   val isOpen: StoryQuestionsAtom => Boolean =

--- a/app/util/AtomUpdateOperations.scala
+++ b/app/util/AtomUpdateOperations.scala
@@ -13,7 +13,7 @@ object AtomUpdateOperations {
   def updateTopLevelFields(atom: Atom, user: User, publish: Boolean = false): Atom =
     atom.copy(
       contentChangeDetails = buildContentChangeDetails(user, Some(atom.contentChangeDetails), updateLastModified = true, updatePublished = publish),
-      defaultHtml = buildDefaultHtml(atom.atomType, atom.data)
+      defaultHtml = buildDefaultHtml(atom).getOrElse("")
     )
 
   def updateAtomFromJson(atom: Atom, json: Json, user: User): Either[AtomAPIError, Atom] = jsonToAtom(atom.asJson.deepMerge(json))

--- a/app/util/AtomUpdateOperations.scala
+++ b/app/util/AtomUpdateOperations.scala
@@ -13,7 +13,7 @@ object AtomUpdateOperations {
   def updateTopLevelFields(atom: Atom, user: User, publish: Boolean = false): Atom =
     atom.copy(
       contentChangeDetails = buildContentChangeDetails(user, Some(atom.contentChangeDetails), updateLastModified = true, updatePublished = publish),
-      defaultHtml = buildDefaultHtml(atom).getOrElse("")
+      defaultHtml = buildDefaultHtml(atom)
     )
 
   def updateAtomFromJson(atom: Atom, json: Json, user: User): Either[AtomAPIError, Atom] = jsonToAtom(atom.asJson.deepMerge(json))

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,8 @@ libraryDependencies ++= Seq(
   "com.gu"                   %% "pan-domain-auth-play_2-5"     % "0.4.1",
   "io.circe"                 %% "circe-parser"                 % "0.7.0",
   "net.logstash.logback"     %  "logstash-logback-encoder"     % "4.2",
-  "com.gu"                   %% "exact-target-lists"           % "0.1"
+  "com.gu"                   %% "exact-target-lists"           % "0.1",
+  "com.gu"                   %% "atom-renderer"                % "0.9.1"
 )
 
 resolvers ++= Seq(


### PR DESCRIPTION
That was added back when we needed a preview of the atom in composer, but since we are using the iframe instead (soon the library), we don't need this anymore.

That will also fix a bug in dotcom/apps where closed reader questions still show up, because `defaultHtml` is spliced in the body of articles.