### PR TITLE
Add Commons Division atoms

### DIFF
--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -87,10 +87,9 @@ class App(val wsClient: WSClient, val atomWorkshopDB: AtomWorkshopDBAPI,
     }
   }
 
-
   def createAtom(atomType: String) = CORSable(Config.workflowUrl) {
     AuthAction { req =>
-      APIResponse{
+      APIResponse {
         for {
           atomType <- validateAtomType(atomType)
           createAtomFields <- extractCreateAtomFields(req.body.asJson.map(_.toString))

--- a/app/models/CreateAtomFields.scala
+++ b/app/models/CreateAtomFields.scala
@@ -1,3 +1,3 @@
 package models
 
-case class CreateAtomFields(title: Option[String], commissioningDesks: Seq[String], defaultHtml: Option[String])
+case class CreateAtomFields(title: Option[String], id: Option[String], commissioningDesks: Seq[String], defaultHtml: Option[String])

--- a/app/util/AtomElementBuilders.scala
+++ b/app/util/AtomElementBuilders.scala
@@ -8,6 +8,7 @@ import com.gu.contentatom.thrift.atom.profile.ProfileAtom
 import com.gu.contentatom.thrift.atom.guide.GuideAtom
 import com.gu.contentatom.thrift.atom.timeline.TimelineAtom
 import com.gu.contentatom.thrift.atom.explainer.{DisplayType, ExplainerAtom}
+import com.gu.contentatom.thrift.atom.commonsdivision.{CommonsDivision, Votes}
 import com.gu.contentatom.thrift.{User, _}
 import com.gu.pandomainauth.model.{User => PandaUser}
 import models.CreateAtomFields
@@ -38,6 +39,8 @@ object AtomElementBuilders {
 
   def buildDefaultAtom(atomType: AtomType, user: PandaUser, createAtomFields: Option[CreateAtomFields]): Atom = {
     val title = createAtomFields.flatMap(_.title).getOrElse("-")
+    val id = createAtomFields.flatMap(_.id).getOrElse(java.util.UUID.randomUUID.toString)
+
     val defaultAtoms: Map[AtomType, AtomData] = Map(
       AtomType.Cta -> AtomData.Cta(CTAAtom("-")),
       AtomType.Recipe -> AtomData.Recipe(RecipeAtom(title, RecipeTags(), RecipeTime())),
@@ -46,13 +49,14 @@ object AtomElementBuilders {
       AtomType.Qanda -> AtomData.Qanda(QAndAAtom(Some("Q&A"), None, QAndAItem(None, "Body"), None)),
       AtomType.Guide -> AtomData.Guide(GuideAtom(None, None, Nil)),
       AtomType.Profile -> AtomData.Profile(ProfileAtom(None, None, Nil, None)),
-      AtomType.Timeline -> AtomData.Timeline(TimelineAtom())
+      AtomType.Timeline -> AtomData.Timeline(TimelineAtom()),
+      AtomType.Commonsdivision -> AtomData.CommonsDivision(CommonsDivision("-", None, DateTime.now.getMillis, Votes()))
     )
 
     Atom(
       title = createAtomFields.flatMap(_.title),
       commissioningDesks = createAtomFields.map(_.commissioningDesks).getOrElse(Nil),
-      id = java.util.UUID.randomUUID.toString,
+      id = id,
       atomType = atomType,
       defaultHtml = createAtomFields.flatMap(_.defaultHtml).getOrElse(buildDefaultHtml(atomType = atomType, atomData = defaultAtoms(atomType))),
       data = defaultAtoms(atomType),

--- a/conf/routes
+++ b/conf/routes
@@ -45,3 +45,6 @@ GET     /reindex-publish                         com.gu.atom.play.ReindexControl
 # Custom atom actions
 POST    /api/live/:atomType/:id/custom/notifications controllers.AtomActions.createNotificationList(atomType: String, id: String)
 DELETE  /api/live/:atomType/:id/custom/notifications controllers.AtomActions.deleteNotificationList(atomType: String, id: String)
+
+# Commons divisions
+GET     /commonsdivisions                        controllers.App.index(placeholder = "")

--- a/public/images/typeicons/commonsdivision-icon.svg
+++ b/public/images/typeicons/commonsdivision-icon.svg
@@ -1,0 +1,1 @@
+<svg width="18px" height="18px" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" fill="#FFFFFF"></svg>

--- a/public/js/BaseApp.js
+++ b/public/js/BaseApp.js
@@ -11,6 +11,7 @@ import AtomList from './components/AtomList/AtomList';
 import ExternalAtom from './components/ExternalAtom/ExternalAtom';
 import AtomRoot from './components/AtomRoot/AtomRoot';
 import ContentSuggestions from './components/ContentSuggestions/ContentSuggestions';
+import CommonsDivisions from './components/CommonsDivisions/CommonsDivisions';
 
 
 export const BaseApp = (props) => (
@@ -26,6 +27,7 @@ export const BaseApp = (props) => (
         </Route>
         <Route path="/external-atoms/:atomType/:id/link" component={ExternalAtom} />
         <Route path="/suggestions" component={ContentSuggestions} />
+        <Route path="/commonsdivisions" component={CommonsDivisions} />
         <IndexRedirect to="/find" />
       </Route>
     </Router>

--- a/public/js/actions/ParliamentActions/getLatestCommonsDivisions.js
+++ b/public/js/actions/ParliamentActions/getLatestCommonsDivisions.js
@@ -1,0 +1,91 @@
+import {latestCommonsDivisions} from '../../services/Parliament';
+import AtomsApi from '../../services/AtomsApi';
+import {logError} from '../../util/logger';
+import {PropTypes} from 'react';
+import {atomPropType} from '../../constants/atomPropType';
+
+const MPPropType = PropTypes.shape({
+  name: PropTypes.string.isRequired,
+  party: PropTypes.string.isRequired
+});
+
+export const CommonsDivisionPropType = PropTypes.shape({
+  parliamentId: PropTypes.string.isRequired,
+  date: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  votes: PropTypes.shape({
+    ayes: PropTypes.arrayOf(MPPropType),
+    noes: PropTypes.arrayOf(MPPropType)
+  })
+});
+
+export const CommonsDivisionResultPropType = PropTypes.shape({
+  division: CommonsDivisionPropType.required,
+  atom: atomPropType
+});
+
+function requestLatestCommonsDivisions() {
+  return {
+    type:       'COMMONS_DIVISIONS_GET_REQUEST',
+    receivedAt: Date.now()
+  };
+}
+
+function receiveLatestCommonsDivisions(commonsDivisions) {
+  return {
+    type:       'COMMONS_DIVISIONS_GET_RECEIVE',
+    commonsDivisions: commonsDivisions,
+    receivedAt: Date.now()
+  };
+}
+
+function errorReceivingLatestCommonsDivisions(error) {
+  logError(error);
+  return {
+    type:       'SHOW_ERROR',
+    message:    'Could not get latest commons divisions',
+    error:      error,
+    receivedAt: Date.now()
+  };
+}
+
+/**
+ * Gets latest divisions from parliament api, and checks for existing atoms.
+ * Returns an array of CommonsDivisionResultPropType
+ */
+export function getLatestCommonsDivisions() {
+  return dispatch => {
+    dispatch(requestLatestCommonsDivisions());
+
+    return latestCommonsDivisions()
+      .then(data => {
+        const items = data.result.items;
+        return Promise.all(items.map(item => {
+          const parliamentId = item["_about"].split("/").pop();
+          const id = `division-${parliamentId}`;
+
+          const divisionData = {
+            division: {
+              parliamentId: parliamentId,
+              date: item.date["_value"],
+              title: item.title
+            }
+          };
+
+          return AtomsApi.getAtom("commonsdivision", id)
+            .then(res => res.json())
+            .then(atom => {
+              divisionData.atom = atom;
+              return divisionData;
+            })
+            .catch(() => divisionData); //No atom exists, this is fine
+        }));
+      })
+      .then(results => {
+        dispatch(receiveLatestCommonsDivisions(results));
+      })
+      .catch(error => {
+        dispatch(errorReceivingLatestCommonsDivisions(error));
+      });
+  };
+}

--- a/public/js/components/AtomCreate/AtomCreateTypeSelect.js
+++ b/public/js/components/AtomCreate/AtomCreateTypeSelect.js
@@ -8,9 +8,10 @@ import {AtomTypeCard} from '../AtomTypeCard/AtomTypeCard';
 export class AtomCreateTypeSelect extends React.Component {
 
   renderAtomType(atomType) {
+    const path = atomType.type === "commonsdivision" ? "/commonsdivisions" : `/create/${atomType.type}`;
     return (
       <Link
-        to={`/create/${atomType.type}`}
+        to={path}
         className={"create__link"}
         key={atomType.type}
         >

--- a/public/js/components/AtomEdit/AtomEdit.js
+++ b/public/js/components/AtomEdit/AtomEdit.js
@@ -7,6 +7,7 @@ import {GuideEditor} from './CustomEditors/GuideEditor';
 import {ProfileEditor} from './CustomEditors/ProfileEditor';
 import {TimelineEditor} from './CustomEditors/TimelineEditor';
 import {ExplainerEditor} from './CustomEditors/ExplainerEditor';
+import {CommonsDivisionEditor} from './CustomEditors/CommonsDivisionEditor';
 import EmbeddedAtomPick from './EmbeddedAtomPick';
 import {subscribeToPresence, enterPresence} from '../../services/presence';
 import AtomEditHeader from './AtomEditHeader';
@@ -75,6 +76,8 @@ class AtomEdit extends React.Component {
         return <TimelineEditor atom={this.props.atom} onUpdate={this.updateAtom} onFormErrorsUpdate={this.updateFormErrors} />;
       case("explainer"):
         return <ExplainerEditor atom={this.props.atom} onUpdate={this.updateAtom} onFormErrorsUpdate={this.updateFormErrors} />;
+      case ("commonsdivision"):
+        return <CommonsDivisionEditor atom={this.props.atom} onUpdate={this.updateAtom} onFormErrorsUpdate={this.updateFormErrors} />;
       default:
         return (
           <div>Atom Workshop cannot edit this type of atom currently</div>

--- a/public/js/components/AtomEdit/CustomEditors/CommonsDivisionEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/CommonsDivisionEditor.js
@@ -1,0 +1,54 @@
+import React, { PropTypes } from 'react';
+
+import {ManagedForm, ManagedField} from '../../ManagedEditor';
+import FormFieldTextInput from '../../FormFields/FormFieldTextInput';
+import moment from 'moment';
+import {atomPropType} from '../../../constants/atomPropType';
+
+export class CommonsDivisionEditor extends React.Component {
+
+  static propTypes = {
+    atom: atomPropType.isRequired,
+    onUpdate: PropTypes.func.isRequired,
+    onFormErrorsUpdate: PropTypes.func
+  }
+
+  renderDetails(details) {
+    return (
+      <div>
+        <div>
+          <b>Date of vote: </b>
+          <span>{moment(details.date).format("DD/MM/YYYY")}</span>
+        </div>
+        <div>
+          <table className={"divisions-table"}>
+            <tbody>
+              <tr>
+                <th>Ayes</th>
+                <th>Noes</th>
+              </tr>
+              <tr>
+                <td>{details.votes.ayes.length}</td>
+                <td>{details.votes.noes.length}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  }
+
+
+  render () {
+    return (
+      <div className="form">
+        <ManagedForm data={this.props.atom} updateData={this.props.onUpdate} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="commonsDivisionEditor">
+          <ManagedField fieldLocation="data.commonsDivision.description" name="Description">
+            <FormFieldTextInput />
+          </ManagedField>
+        </ManagedForm>
+        {this.props.atom.data.commonsDivision ? this.renderDetails(this.props.atom.data.commonsDivision) : null }
+      </div>
+    );
+  }
+}

--- a/public/js/components/CommonsDivisions/CommonsDivision.js
+++ b/public/js/components/CommonsDivisions/CommonsDivision.js
@@ -1,0 +1,184 @@
+import React from 'react';
+import {CommonsDivisionPropType} from '../../actions/ParliamentActions/getLatestCommonsDivisions.js';
+import {atomPropType} from '../../constants/atomPropType';
+import AtomsApi from '../../services/AtomsApi';
+import {commonsDivision} from '../../services/Parliament';
+import moment from 'moment';
+
+const StatusTypes = {
+  DISPLAY: "DISPLAY",               //display either "Create atom" button or "Edit atom" link
+  RETRIEVE_VOTES: "RETRIEVE_VOTES", //getting the vote data from parliament api
+  CREATE: "CREATE",                 //creating a new default atom
+  UPDATE: "UPDATE",                 //adding the vote data to the atom
+  ERROR:  "ERROR"
+};
+
+class CommonsDivision extends React.Component {
+  static propTypes = {
+    division: CommonsDivisionPropType,
+    atom: atomPropType
+  };
+
+  state = {
+    status: StatusTypes.DISPLAY,
+    division: this.props.division,
+    atom: this.props.atom
+  };
+
+  //Order by second name while building up the MP lists.
+  compareSecondNames = (a, b) => a.split(" ").pop() > b.split(" ").pop();
+  insertMP(mp, arr, start, end) {
+    if (start >= end) {
+      if (arr[start] && this.compareSecondNames(mp.name, arr[start].name)) arr.splice(start+1, 0, mp);
+      else arr.splice(start, 0, mp);
+    } else {
+      const pivot = Math.floor((start + end) / 2);
+      if (this.compareSecondNames(mp.name, arr[pivot].name)) this.insertMP(mp, arr, pivot+1, end);
+      else this.insertMP(mp, arr, start, pivot-1);
+    }
+  }
+
+  cleanPartyName(name) {
+    switch (name) {
+      case "Labour (Co-op)":
+        return "Labour";
+      default:
+        return name;
+    }
+  }
+
+  retrieveVotes(id) {
+    this.setState(Object.assign({}, this.state, {
+      status: StatusTypes.RETRIEVE_VOTES
+    }));
+
+    //Add the votes to the division then create an atom
+    commonsDivision(id).then(data => {
+      const raw = data.result.primaryTopic;
+      const parliamentId = raw["_about"].split("/").pop();
+
+      const division = {
+        parliamentId: parliamentId,
+        date: raw.date["_value"],
+        title: raw.title,
+        votes: {
+          ayes: [],
+          noes: []
+        }
+      };
+
+      raw.vote.forEach(vote => {
+        const type = vote.type.split("#").pop();
+        const mp = {
+          name: vote.memberPrinted["_value"],
+          party: this.cleanPartyName(vote.memberParty)
+        };
+
+        if (type === "AyeVote") this.insertMP(mp, division.votes.ayes, 0, division.votes.ayes.length-1);
+        else if (type === "NoVote") this.insertMP(mp, division.votes.noes, 0, division.votes.noes.length-1);
+      });
+
+      this.setState(Object.assign({}, this.state, {
+        division: division,
+        status: StatusTypes.CREATE
+      }));
+
+      this.createAtom();
+    });
+  }
+
+  createAtom() {
+    const id = `division-${this.state.division.parliamentId}`;
+
+    AtomsApi.createAtom("commonsdivision", {
+      title: this.state.division.title,
+      id: id,
+      commissioningDesks: []
+    }).then(res => res.json())
+      .then(atom => {
+        this.setState(Object.assign({}, this.state, {
+          atom: atom,
+          status: StatusTypes.UPDATE
+        }));
+
+        this.updateAtom();
+      });
+  }
+
+  updateAtom() {
+    const date = moment(this.state.division.date, "YYYY-MM-DD", true);
+
+    const updatedAtom = Object.assign({}, this.state.atom, {
+      data: {
+        commonsDivision: {
+          parliamentId: this.state.division.parliamentId,
+          date: date.valueOf(),
+          votes: this.state.division.votes
+        }
+      }
+    });
+
+    AtomsApi.updateAtom(updatedAtom)
+      .then(res => res.json())
+      .then(atom => {
+        this.setState(Object.assign({}, this.state, {
+          atom: atom,
+          status: StatusTypes.DISPLAY
+        }));
+      });
+  }
+
+  renderAtomLink(atom) {
+    const workshopUrl = `/atoms/commonsdivision/${atom.id}/edit`;
+    return (
+      <a className="atom-list__link" href={workshopUrl}>Edit atom</a>
+    );
+  }
+
+  renderCreateButton(id) {
+    return (
+      <button className="btn" onClick={this.retrieveVotes.bind(this, id)}>Create atom</button>
+    );
+  }
+
+  /**
+   * Depending on the current state, the management div may contain:
+   * 1. 'Create atom' button
+   * 2. 'Edit atom' link
+   * 3. A status message indicating progress of atom creation from parliament api data
+   */
+  renderManagement() {
+    switch (this.state.status) {
+      case StatusTypes.RETRIEVE_VOTES:
+        return (<div>Retrieving votes...</div>);
+
+      case StatusTypes.CREATE:
+        return (<div>Creating atom...</div>);
+
+      case StatusTypes.UPDATE:
+        return (<div>Adding votes...</div>);
+
+      case StatusTypes.DISPLAY:
+        return (
+          <div
+            className="divisions-action"> {
+            this.state.atom ? this.renderAtomLink(this.state.atom) : this.renderCreateButton(this.state.division.parliamentId)
+          }
+          </div>
+        );
+      case StatusTypes.ERROR:
+        return (<div>Error creating atom</div>);
+    }
+  }
+
+  render() {
+    return (
+      <li className="divisions-list__item" key={this.state.division.parliamentId}>
+        <div className="divisions-description">{this.state.division.date} - <span className="divisions-list__item__title">{this.state.division.title}</span></div>
+        {this.renderManagement.bind(this)()}
+      </li>
+    );
+  }
+}
+
+export default CommonsDivision;

--- a/public/js/components/CommonsDivisions/CommonsDivisions.js
+++ b/public/js/components/CommonsDivisions/CommonsDivisions.js
@@ -1,0 +1,57 @@
+import React, {PropTypes} from 'react';
+import {CommonsDivisionResultPropType} from '../../actions/ParliamentActions/getLatestCommonsDivisions.js';
+import CommonsDivision from './CommonsDivision';
+import moment from 'moment';
+
+class CommonsDivisions extends React.Component {
+  static propTypes = {
+    commonsDivisions: PropTypes.arrayOf(CommonsDivisionResultPropType),
+    atomActions: PropTypes.shape({
+      getLatestCommonsDivisions: PropTypes.func.isRequired
+    }).isRequired
+  };
+
+  componentWillMount() {
+    this.props.atomActions.getLatestCommonsDivisions();
+  }
+
+  render() {
+    if (this.props.commonsDivisions) {
+      return (
+        <div>
+          <h2 className="divisions-heading">Latest Commons Divisions (as of {moment().format("HH:mm")})</h2>
+          <div className="atom-editor divisions-container">
+            <ul className="divisions-list">
+            {
+              this.props.commonsDivisions.map(data => {
+                return (<CommonsDivision key={data.division.parliamentId} atom={data.atom} division={data.division}/>);
+              })
+            }
+            </ul>
+          </div>
+        </div>
+      );
+    } else {
+      return (<div>Loading the latest commons divisions from data.parliament.uk...</div>);
+    }
+  }
+}
+
+//REDUX CONNECTIONS
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import * as getLatestCommonsDivisions from '../../actions/ParliamentActions/getLatestCommonsDivisions.js';
+
+function mapStateToProps(state) {
+  return {
+    commonsDivisions: state.commonsDivisions
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    atomActions: bindActionCreators(Object.assign({}, getLatestCommonsDivisions), dispatch)
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(CommonsDivisions);

--- a/public/js/constants/atomData.js
+++ b/public/js/constants/atomData.js
@@ -78,8 +78,15 @@ export const explainer = {
   description: "Edit legacy Explainer snippets - (creating new ones is not supported)",
 };
 
-export const allAtomTypes = [cta, recipe, storyQuestions, quiz, media, qa, guide, profile, timeline, explainer];
-export const workshopEditableAtomTypes = [cta, storyQuestions, recipe, qa, guide, profile, timeline, explainer];
+export const commonsDivision = {
+  type: "commonsdivision",
+  fullName: "Commons Division",
+  description: "House of Commons division results"
+};
+
+export const allAtomTypes = [cta, recipe, storyQuestions, quiz, media, qa, guide, profile, timeline, explainer, commonsDivision];
+export const workshopEditableAtomTypes = [cta, storyQuestions, recipe, qa, guide, profile, timeline, explainer, commonsDivision];
+
 export const snippetAtomTypes = [qa, guide, profile, timeline];
 export const legacyAtomTypes = [explainer];
 

--- a/public/js/reducers/commonsDivisionsReducer.js
+++ b/public/js/reducers/commonsDivisionsReducer.js
@@ -1,0 +1,10 @@
+export default function commonsDivisions(state = null, action) {
+  switch (action.type) {
+
+    case 'COMMONS_DIVISIONS_GET_RECEIVE':
+      return action.commonsDivisions || null;
+
+    default:
+      return state;
+  }
+}

--- a/public/js/reducers/rootReducer.js
+++ b/public/js/reducers/rootReducer.js
@@ -14,6 +14,7 @@ import suggestionsForLatestContent from '../reducers/suggestionsForLatestContent
 import externalAtom from '../reducers/externalAtomReducer';
 import queryParams from '../reducers/queryParamsReducer';
 import workflow from '../reducers/workflowReducer';
+import commonsDivisions from '../reducers/commonsDivisionsReducer';
 import {routerReducer} from 'react-router-redux';
 
 export const rootReducer = combineReducers({
@@ -31,5 +32,6 @@ export const rootReducer = combineReducers({
   externalAtom,
   queryParams,
   workflow,
+  commonsDivisions,
   routing: routerReducer
 });

--- a/public/js/services/Parliament.js
+++ b/public/js/services/Parliament.js
@@ -1,0 +1,25 @@
+import { pandaFetch } from './pandaFetch';
+
+export const latestCommonsDivisions = () => {
+  return pandaFetch(
+    'https://lda.data.parliament.uk/commonsdivisions.json',
+    {
+      method: 'get',
+      credentials: 'same-origin'
+    }
+  )
+  .then((res) => res.json())
+  .then((json) => Promise.resolve(json));
+};
+
+export const commonsDivision = (parliamentId) => {
+  return pandaFetch(
+    `https://lda.data.parliament.uk/commonsdivisions/${parliamentId}.json`,
+    {
+      method: 'get',
+      credentials: 'same-origin'
+    }
+  )
+    .then((res) => res.json())
+    .then((json) => Promise.resolve(json));
+};

--- a/public/styles/components/_commons-divisions.scss
+++ b/public/styles/components/_commons-divisions.scss
@@ -1,0 +1,73 @@
+.divisions-heading {
+  text-align: center;
+}
+
+.divisions-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+
+  .atom-embed {
+    min-height: inherit;
+  }
+}
+
+.divisions-container {
+  display: flex;
+}
+
+.divisions-list__item {
+  padding: 10px 0;
+  display: flex;
+  max-height: 200px;
+
+  &__title {
+    font-weight: bold;
+    font-size: 18px;
+    margin-bottom: 2px
+  }
+
+  &:not(:last-child) {
+    border-bottom: 4px solid $color300Grey;
+  }
+}
+
+.divisions-headline, .divisions-list__links {
+  display: inline-block;
+  padding-top: 10px;
+}
+
+.divisions-list__details {
+  margin-right: 10px;
+}
+
+.divisions-list__link {
+  padding-left: 10px;
+}
+
+.divisions-description {
+  flex-basis: 80%;
+  flex-shrink: 0;
+  border-right: 1px solid #DCDCDC;
+  margin-right: 10px;
+  padding-right: 5px;
+}
+
+.divisions-action {
+  float: right;
+  overflow-y: auto;
+}
+
+.divisions-table {
+  width: 100%;
+  margin-top: 20px
+}
+
+
+.divisions-table th {
+  font-size: 17px;
+}
+.divisions-table td {
+  text-align: center;
+}

--- a/public/styles/main.scss
+++ b/public/styles/main.scss
@@ -40,4 +40,5 @@
 'components/atom-actions',
 'components/workflow',
 'components/targeting',
-'components/suggestions';
+'components/suggestions',
+'components/commons-divisions';


### PR DESCRIPTION
1. Selecting this type from the Create Atom page directs to `/commonsdivisions`. This page lists the latest divisions from the data.parliament api. For each division it displays either a "Create atom" button or an "Edit atom" link (depending on whether or not the atom exists yet).
2. The editor page for this atom only allows the user to change the description field.
3. The atoms are stored in the general atom-workshop dynamo tables, though the id is generated differently to allow lookups based on the parliament ID (`division-<parliamentId>`).

#### Create atom page:
<img width="572" alt="picture 15" src="https://user-images.githubusercontent.com/1513454/33934897-1540c2ea-dff2-11e7-8981-85b62aeb0676.png">

#### Edit atom page:
<img width="558" alt="picture 16" src="https://user-images.githubusercontent.com/1513454/33934898-1559065c-dff2-11e7-9cf0-06eb947c138e.png">
