### PR TITLE
Panda authed preview capi

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -71,6 +71,7 @@ object Config extends AwsInstanceTags {
   val presenceDomain = getPropertyIfEnabled(presenceEnabled, "presence.domain")
 
   val capiPreviewUrl = config.getString("capi.previewUrl")
+  val capiPandaPreviewUrl = config.getString("capi.pandaPreviewUrl")
   val capiLiveUrl = config.getString("capi.liveUrl")
   val capiUsername = config.getString("capi.previewUsername")
   val capiPassword = config.getString("capi.previewPassword")

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -9,15 +9,19 @@ class Support(val wsClient: WSClient) extends Controller with PanDomainAuthActio
 
   def previewCapiProxy(path: String) = APIAuthAction.async { request =>
 
+    val authCookieName = "gutoolsAuth-assym"
+    val cookie = request.cookies.get(authCookieName).fold("")(_.value)
+
     val capiPreviewUser = Config.capiUsername
     val capiPreviewPassword = Config.capiPassword
     val capiUrl = Config.capiPreviewUrl
+    val pandaPreviewUrl = Config.capiPandaPreviewUrl
 
-    val url = s"$capiUrl/$path?${request.rawQueryString}"
+    val url = s"$pandaPreviewUrl/$path?${request.rawQueryString}"
 
     val req = wsClient
       .url(url)
-      .withAuth(capiPreviewUser, capiPreviewPassword, WSAuthScheme.BASIC)
+      .withHeaders("Cookie" -> s"$authCookieName=$cookie")
       .get()
 
     req.map(response => response.status match {


### PR DESCRIPTION
*** DO NOT MERGE***

This is a PR to demonstrate swapping to using panda-authenticated preview capi requests. For more details please see this [doc](https://docs.google.com/a/guardian.co.uk/document/d/1EDOmG7oul3cQQ2bps29HXEZolLGAOCxsAMYGc763zhM/edit?usp=sharing). 

TODO: 
- [ ] Update conf file: add field `pandaPreviewUrl` inside capi object with new url



Before this PR can be merged we need to create a PROD and DEV stack on the capi side. 

For more details on this speak to @tomrf1 