### PR TITLE
Allow array elements to be reordered

### DIFF
--- a/public/js/components/AtomEdit/AtomEdit.js
+++ b/public/js/components/AtomEdit/AtomEdit.js
@@ -7,11 +7,10 @@ import {GuideEditor} from './CustomEditors/GuideEditor';
 import {ProfileEditor} from './CustomEditors/ProfileEditor';
 import {TimelineEditor} from './CustomEditors/TimelineEditor';
 import EmbeddedAtomPick from './EmbeddedAtomPick';
-
 import {subscribeToPresence, enterPresence} from '../../services/presence';
-
 import AtomEditHeader from './AtomEditHeader';
 import {atomPropType} from '../../constants/atomPropType';
+import {logError} from '../../util/logger';
 
 class AtomEdit extends React.Component {
 
@@ -43,7 +42,7 @@ class AtomEdit extends React.Component {
     try {
         enterPresence(this.props.routeParams.atomType, this.props.routeParams.id);
     } catch (e) {
-      console.warn(e);
+        logError(e);
     } finally {
         this.props.atomActions.updateAtom(newAtom);
     }

--- a/public/js/components/AtomEdit/AtomEdit.js
+++ b/public/js/components/AtomEdit/AtomEdit.js
@@ -40,8 +40,13 @@ class AtomEdit extends React.Component {
   }
 
   updateAtom = (newAtom) => {
-    this.props.atomActions.updateAtom(newAtom);
-    enterPresence(this.props.routeParams.atomType, this.props.routeParams.id);
+    try {
+        enterPresence(this.props.routeParams.atomType, this.props.routeParams.id);
+    } catch (e) {
+      console.warn(e);
+    } finally {
+        this.props.atomActions.updateAtom(newAtom);
+    }
   }
 
   updateFormErrors = (errors) => {

--- a/public/js/components/FormFields/FormFieldArrayWrapper.js
+++ b/public/js/components/FormFields/FormFieldArrayWrapper.js
@@ -65,6 +65,19 @@ export default class FormFieldArrayWrapper extends React.Component {
       }
     };
 
+    const moveInArrayFn = (arr, fromIndex, toIndex) => {
+        arr.splice(toIndex, 0, arr.splice(fromIndex, 1)[0]);
+    };
+    
+    const moveFn = (currentIndex, newIndex) => {
+     /* we only allow to move if item has been updated and indices are within array bounds */
+     if (value !== undefined && this.props.fieldValue && this.props.fieldValue.length > currentIndex && currentIndex >= 0 && this.props.fieldValue.length > newIndex && newIndex >= 0) {
+        const newFieldValue = this.props.fieldValue.slice();
+        moveInArrayFn(newFieldValue, currentIndex, newIndex);
+        this.props.onUpdateField(newFieldValue);
+     }
+    };
+
     const hydratedChildren = React.Children.map(this.props.children, (child) => {
       return React.cloneElement(child, {
         key: `${this.props.fieldName}-${i}`,
@@ -80,6 +93,10 @@ export default class FormFieldArrayWrapper extends React.Component {
       <div className={this.props.fieldClass ? this.props.fieldClass : 'form__group form__field'}>
         {this.props.numbered ? <span className="form__field-number">{`${i + 1}. `}</span> : false }
         {hydratedChildren}
+        // TODO enable only if value is not undefined and i is not 0 or the last one
+        // TODO style properly so all buttons are one the same line
+        <button className="btn form__field-btn" type="button" onClick= { moveFn.bind(this, i, (i-1) ) } > Move up </button> 
+        <button className="btn form__field-btn" type="button" onClick= { moveFn.bind(this, i, (i+1) ) } > Move down </button>
         <button className="btn form__field-btn btn--red" type="button" onClick={removeFn.bind(this, i)}>Delete</button>
       </div>
     );

--- a/public/js/components/FormFields/FormFieldArrayWrapper.js
+++ b/public/js/components/FormFields/FormFieldArrayWrapper.js
@@ -1,5 +1,4 @@
 import React, {PropTypes} from 'react';
-import ReactDOM from 'react-dom';
 import { errorPropType } from '../../constants/errorPropType';
 
 export default class FormFieldArrayWrapper extends React.Component {
@@ -82,13 +81,22 @@ export default class FormFieldArrayWrapper extends React.Component {
               moveInArrayFn(arr, currentIndex, newIndex);
               this.props.onUpdateField(arr);
           }
+          
+          // When reordering array elements & the child is a scribe editor, we have no way of passing information
+          // down to scribe to force a re-render, as scribe cannot handle update changes once it has been
+          // initialised. To trigger the visual change without a browser refresh, we need to unmount
+          // and remount the child scribe component. However as we only render the root React component
+          // with the DOM, and every other downstream component is rendered via React, there is no way to
+          // remove the children components. Therefore we use this flag in state to identify whether
+          // they should be visible or not. We hide the component until the updates have passed downstream,
+          // and then the further change in state below will trigger a re-render & the lifecycle methods of any children.
 
           this.setState({
             childrenVisible: true
           });
 
         });
-    }
+    };
 
 
     const hydratedChildren = React.Children.map(this.props.children, (child) => {
@@ -102,24 +110,24 @@ export default class FormFieldArrayWrapper extends React.Component {
       });
     });
 
-    const returnMoveBtns = () => {
+    const renderMoveBtns = () => {
       if (i !== 0 && (i+1) < this.props.fieldValue.length) {
         return <div>
               <button className="btn form__field-btn form__field--move-btn" type="button" onClick= { moveFn.bind(this, i, (i-1) ) } >Move up</button>
               <button className="btn form__field-btn form__field--move-btn" type="button" onClick= { moveFn.bind(this, i, (i+1) ) } >Move down </button>
-            </div>
+            </div>;
       } else if (i === 0) {
-        return <div><button className="btn form__field-btn form__field--move-btn" type="button" onClick= { moveFn.bind(this, i, (i+1) ) } >Move down </button></div>
+        return <div><button className="btn form__field-btn form__field--move-btn" type="button" onClick= { moveFn.bind(this, i, (i+1) ) } >Move down </button></div>;
       } else {
-        return <div><button className="btn form__field-btn form__field--move-btn" type="button" onClick= { moveFn.bind(this, i, (i-1) ) } >Move up</button></div>
+        return <div><button className="btn form__field-btn form__field--move-btn" type="button" onClick= { moveFn.bind(this, i, (i-1) ) } >Move up</button></div>;
       }
-    }
+    };
 
     return (
       <div className={this.props.fieldClass ? this.props.fieldClass : 'form__group form__field'}>
         {this.props.numbered ? <span className="form__field-number">{`${i + 1}. `}</span> : false }
         {hydratedChildren}
-        {returnMoveBtns()}
+        {renderMoveBtns()}
         <button className="btn form__field-btn btn--red" type="button" onClick={removeFn.bind(this, i)}>Delete</button>
       </div>
     );

--- a/public/js/components/FormFields/FormFieldScribeEditor.js
+++ b/public/js/components/FormFields/FormFieldScribeEditor.js
@@ -6,6 +6,7 @@ import scribePluginLinkPromptCommand from 'scribe-plugin-link-prompt-command';
 import scribePluginSanitizer from 'scribe-plugin-sanitizer';
 import {errorPropType} from '../../constants/errorPropType';
 import ShowErrors from '../Utilities/ShowErrors';
+import uuidv4 from 'uuid/v4';
 
 export default class FormFieldsScribeEditor extends React.Component {
 
@@ -71,24 +72,17 @@ export class ScribeEditor extends React.Component {
   };
 
   state = {
-    scribeElement: null,
+    scribeElement: null
   };
 
+  uid = uuidv4();
+
   componentDidMount() {
-      this.setState({scribeElement: document.getElementById(this.props.fieldName)}, () => {
+      this.setState({scribeElement: document.getElementById(this.props.fieldName+this.uid)}, () => {
         this.configureScribe();
       });
 
   }
-
-  componentDidUpdate(prevProps, prevState) {
-
-    /*
-     * uncomment line below to have array reordering works correctly but break scribe editor
-     */
-      this.state.scribeElement.innerHTML = this.props.value;
-  }
-
 
   configureScribe = () => {
 
@@ -96,7 +90,7 @@ export class ScribeEditor extends React.Component {
 
     // Create an instance of the Scribe toolbar
     if (this.props.showToolbar !== false) {
-      const toolbar = document.getElementById("scribe__toolbar");
+      const toolbar = document.getElementById(`scribe__toolbar-${this.uid}`);
       this.scribe.use(scribePluginToolbar(toolbar));
     }
 
@@ -143,7 +137,7 @@ export class ScribeEditor extends React.Component {
     return (
         <div>
           { this.props.showToolbar === false ? null :
-            <div id="scribe__toolbar" className="scribe__toolbar">
+            <div id={`scribe__toolbar-${this.uid}`} className="scribe__toolbar">
               <button type="button" data-command-name="bold" className="scribe__toolbar__item">Bold</button>
               <button type="button" data-command-name="italic" className="scribe__toolbar__item">Italic</button>
               <button type="button" data-command-name="linkPrompt" className="scribe__toolbar__item">Link</button>
@@ -151,7 +145,7 @@ export class ScribeEditor extends React.Component {
             </div>
           }
 
-          <div id={this.props.fieldName} className="scribe__editor"></div>
+          <div id={this.props.fieldName + this.uid} className="scribe__editor"></div>
         </div>
   );
   }

--- a/public/js/components/FormFields/FormFieldScribeEditor.js
+++ b/public/js/components/FormFields/FormFieldScribeEditor.js
@@ -80,6 +80,14 @@ export class ScribeEditor extends React.Component {
     this.refs.editor.innerHTML = this.props.value;
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    /* 
+     * uncomment line below to have array reordering works correctly but break scribe editor
+     */ 
+    // this.refs.editor.innerHTML = this.props.value; */
+  }
+
+
   configureScribe() {
     // Create an instance of the Scribe toolbar
     if (this.props.showToolbar !== false) {

--- a/public/js/components/FormFields/FormFieldScribeEditor.js
+++ b/public/js/components/FormFields/FormFieldScribeEditor.js
@@ -75,10 +75,10 @@ export class ScribeEditor extends React.Component {
     scribeElement: null
   };
 
-  uid = uuidv4();
+  uuid = uuidv4();
 
   componentDidMount() {
-      this.setState({scribeElement: document.getElementById(this.props.fieldName+this.uid)}, () => {
+      this.setState({scribeElement: document.getElementById(this.props.fieldName+this.uuid)}, () => {
         this.configureScribe();
       });
 
@@ -90,7 +90,7 @@ export class ScribeEditor extends React.Component {
 
     // Create an instance of the Scribe toolbar
     if (this.props.showToolbar !== false) {
-      const toolbar = document.getElementById(`scribe__toolbar-${this.uid}`);
+      const toolbar = document.getElementById(`scribe__toolbar-${this.uuid}`);
       this.scribe.use(scribePluginToolbar(toolbar));
     }
 
@@ -118,7 +118,14 @@ export class ScribeEditor extends React.Component {
     }));
 
     this.scribe.on('content-changed', this.onContentChange);
-    this.state.scribeElement.innerHTML = this.props.value;
+
+    const updatedScribeElem = Object.assign({}, this.state.scribeElement, {
+        innerHtml: this.props.value
+    });
+
+    this.setState({
+        scribeElement: updatedScribeElem
+    });
 
   }
 
@@ -137,7 +144,7 @@ export class ScribeEditor extends React.Component {
     return (
         <div>
           { this.props.showToolbar === false ? null :
-            <div id={`scribe__toolbar-${this.uid}`} className="scribe__toolbar">
+            <div id={`scribe__toolbar-${this.uuid}`} className="scribe__toolbar">
               <button type="button" data-command-name="bold" className="scribe__toolbar__item">Bold</button>
               <button type="button" data-command-name="italic" className="scribe__toolbar__item">Italic</button>
               <button type="button" data-command-name="linkPrompt" className="scribe__toolbar__item">Link</button>
@@ -145,7 +152,7 @@ export class ScribeEditor extends React.Component {
             </div>
           }
 
-          <div id={this.props.fieldName + this.uid} className="scribe__editor"></div>
+          <div id={this.props.fieldName + this.uuid} className="scribe__editor"></div>
         </div>
   );
   }

--- a/public/js/components/FormFields/FormFieldScribeEditor.js
+++ b/public/js/components/FormFields/FormFieldScribeEditor.js
@@ -68,30 +68,36 @@ export class ScribeEditor extends React.Component {
     value: PropTypes.string,
     onUpdate: PropTypes.func,
     showToolbar: PropTypes.bool
-  }
+  };
+
+  state = {
+    scribeElement: null,
+  };
 
   componentDidMount() {
-    this.scribe = new Scribe(this.refs.editor);
+      this.setState({scribeElement: document.getElementById(this.props.fieldName)}, () => {
+        this.configureScribe();
+      });
 
-    this.configureScribe();
-
-    this.scribe.on('content-changed', this.onContentChange);
-
-    this.refs.editor.innerHTML = this.props.value;
   }
 
   componentDidUpdate(prevProps, prevState) {
-    /* 
+
+    /*
      * uncomment line below to have array reordering works correctly but break scribe editor
-     */ 
-    // this.refs.editor.innerHTML = this.props.value; */
+     */
+      this.state.scribeElement.innerHTML = this.props.value;
   }
 
 
-  configureScribe() {
+  configureScribe = () => {
+
+    this.scribe = new Scribe(this.state.scribeElement);
+
     // Create an instance of the Scribe toolbar
     if (this.props.showToolbar !== false) {
-      this.scribe.use(scribePluginToolbar(this.refs.toolbar));
+      const toolbar = document.getElementById("scribe__toolbar");
+      this.scribe.use(scribePluginToolbar(toolbar));
     }
 
     // Configure Scribe plugins
@@ -117,14 +123,17 @@ export class ScribeEditor extends React.Component {
       }
     }));
 
+    this.scribe.on('content-changed', this.onContentChange);
+    this.state.scribeElement.innerHTML = this.props.value;
+
   }
 
   shouldComponentUpdate(nextProps) {
-    return nextProps.value !== this.refs.editor.innerHTML;
+    return this.state.scribeElement !== null && nextProps.value !== this.state.scribeElement.innerHTML;
   }
 
   onContentChange = () => {
-    const newContent = this.refs.editor.innerHTML;
+    const newContent = this.state.scribeElement.innerHTML;
     if (newContent !== this.props.value) {
       this.props.onUpdate(newContent);
     }
@@ -134,14 +143,15 @@ export class ScribeEditor extends React.Component {
     return (
         <div>
           { this.props.showToolbar === false ? null :
-            <div ref="toolbar" className="scribe__toolbar">
+            <div id="scribe__toolbar" className="scribe__toolbar">
               <button type="button" data-command-name="bold" className="scribe__toolbar__item">Bold</button>
               <button type="button" data-command-name="italic" className="scribe__toolbar__item">Italic</button>
               <button type="button" data-command-name="linkPrompt" className="scribe__toolbar__item">Link</button>
               <button type="button" data-command-name="unlink" className="scribe__toolbar__item">Unlink</button>
             </div>
           }
-          <div id={this.props.fieldName} ref="editor" className="scribe__editor"></div>
+
+          <div id={this.props.fieldName} className="scribe__editor"></div>
         </div>
   );
   }

--- a/public/styles/components/_forms.scss
+++ b/public/styles/components/_forms.scss
@@ -69,6 +69,12 @@
     margin-bottom: 20px;
   }
 
+  &--move-btn {
+    display: inline-block;
+    float: right;
+    margin-right: 2px;
+  }
+
   &--nested {
     border: none;
   }


### PR DESCRIPTION
I have been stuck on this for more than one day because of the Scribe editor. Basically the rendering the editor component is currently done in a way that does not seems compatible with the state being updated outside of the html input:

-   without `componentDidUpdate` method, even if the state is correctly modified the rendered text will still be the old one. 

-  with `componentDidUpdate` method, when reordering (`move up`, `move down`) the html is correctly updated however, the scribe editor does not work anymore.

I have been able to debug that when an edition is done on the scribe editor, the state is not updated at the time the rendering is done, i.e  `this.props.value` in  `componentDidUpdate` will contain the old state :/ 

@shaundillon 