### PR TITLE
Capi iam preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A single tool for all atom types.
 ## Running locally
 
 You'll need the [AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/installing.html) installed, and credentials
-for the composer AWS account from [janus](https://janus.gutools.co.uk). You'll also need to follow the
+for both the composer and capi AWS accounts from [janus](https://janus.gutools.co.uk). You'll also need to follow the
 'Install SSL certificates' step in the [dev-nginx readme](https://github.com/guardian/dev-nginx). Then:
 
  - Fetch config from S3: `./fetch-config.sh`

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,8 @@ libraryDependencies ++= Seq(
   "com.gu"                   %% "pan-domain-auth-play_2-5"     % "0.4.1",
   "io.circe"                 %% "circe-parser"                 % "0.7.0",
   "net.logstash.logback"     %  "logstash-logback-encoder"     % "4.2",
-  "com.gu"                   %% "exact-target-lists"           % "0.1"
+  "com.gu"                   %% "exact-target-lists"           % "0.1",
+  "com.gu"                   %% "content-api-client-aws"       % "0.1"
 )
 
 resolvers ++= Seq(


### PR DESCRIPTION
We are in the process of changing how we authorise access to CAPI preview. In the past we have used basic auth (in Concierge), with the usernames/passwords maintained by the CAPI team.
Instead we will use api-gateway to move authorisation out of concierge and avoid having to maintain usernames/passwords.

The api-gateway uses IAM authorisation. This means the app assumes a cross-account role, and signs each (preview) request using this role.

Note - this means you will now need capi credentials to run the app locally