### PR TITLE
Migrate explainers in AW datastore

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -15,9 +15,10 @@ class AppComponents(context: Context)
 
   val logger = new LogConfig
 
-  lazy val router = new Routes(httpErrorHandler, appController, healthcheckController, loginController, assets, supportController, reindex, atomActionsController)
+  lazy val router = new Routes(httpErrorHandler, appController, healthcheckController, loginController, assets, supportController, reindex, atomActionsController, migrationController)
   lazy val assets = new controllers.Assets(httpErrorHandler)
   lazy val appController = new controllers.App(wsClient, atomWorkshopDB, permissions)
+  lazy val migrationController = new controllers.Migration(wsClient, atomWorkshopDB)
   lazy val loginController = new controllers.Login(wsClient)
   lazy val healthcheckController = new controllers.Healthcheck()
   lazy val supportController = new controllers.Support(wsClient)

--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -48,7 +48,7 @@ class Migration(
     signer.addIAMHeaders(headers = Map.empty, url = url).toSeq
 
   private def queryCapi(pageno: Int): Future[AtomsResponse] = {
-    val url = s"${Config.capiPreviewIAMUrl}/atoms?type=explainer&page=$pageno"
+    val url = s"${Config.capiPreviewIAMUrl}/atoms?format=thrift&type=explainer&page=$pageno"
     wsClient
       .url(url)
       .withHeaders(getHeaders(url): _*)

--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -80,6 +80,7 @@ class Migration(
       result <- ar.results
     } yield {
       val atomFields = CreateAtomFields(
+        id = Some(result.id),
         title = result.data match {
           case a: AtomData.Explainer => Some(a.explainer.title)
           case _ => None

--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -61,8 +61,8 @@ class Migration(
         case _ => Future.failed(new Throwable(s"CAPI error response: ${response.status} / ${response.body}"))
       })
       .flatMap(_.as[AtomsResponse].fold(
-        Future.successful(_),
-        _ => Future.failed(new Throwable(s"CAPI json error"))
+        e => Future.failed(new Throwable(s"CAPI json error: ${e}")),
+        Future.successful(_)
       ))
   }
 

--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -35,6 +35,14 @@ class Migration(
   val atomWorkshopDB: AtomWorkshopDBAPI) 
   extends Controller with PanDomainAuthActions {
 
+  
+  // ------------------------------------------------------------
+  // Public API
+  def migrateExplainers() = AuthAction { req =>
+    Await.result(migrate(req.user)(1), Duration.Inf)
+    Ok("Done!")
+  }
+
   // ------------------------------------------------------------
   // CAPI auth stuff
   private val signer = new IAMSigner(
@@ -57,14 +65,8 @@ class Migration(
       })
       .map(ThriftDeserializer.deserialize[AtomsResponse](_, AtomsResponse))
   }
+
   // ------------------------------------------------------------
-
-
-  def migrateExplainers() = AuthAction { req =>
-    Await.result(migrate(req.user)(1), Duration.Inf)
-    Ok("Done!")
-  }
-
   // Here's how it works:
   // - query CAPI for all live explainers
   // - insert each result in the DynamoDB preview and live stores

--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -1,0 +1,84 @@
+package controllers
+
+import cats.syntax.either._
+import com.gu.editorial.permissions.client.{Permission, PermissionGranted, PermissionsUser}
+import com.gu.pandomainauth.action.UserRequest
+import config.Config
+import db.AtomDataStores._
+import db.AtomWorkshopDBAPI
+import play.api.libs.concurrent.Execution.Implicits._
+import models._
+import play.api.Logger
+import play.api.libs.ws.WSClient
+import play.api.mvc.{ActionBuilder, Controller, Request, Result}
+
+import services.AtomPublishers._
+import services.AtomWorkshopPermissionsProvider
+import util.AtomLogic._
+import util.AtomUpdateOperations._
+import util.AtomElementBuilders
+import play.api.mvc.Action
+
+import com.gu.contentapi.client.model.AtomsQuery
+import com.gu.contentapi.client.model.v1.AtomsResponse
+import com.gu.contentapi.client.GuardianContentClient
+import com.gu.contentatom.thrift.{AtomType, AtomData}
+import com.gu.pandomainauth.model.{User => PandaUser}
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.Duration
+
+class Migration(
+  val wsClient: WSClient, 
+  val capiClient: GuardianContentClient,
+  val atomWorkshopDB: AtomWorkshopDBAPI) 
+  extends Controller with PanDomainAuthActions {
+  
+  def migrateExplainers() = AuthAction { req =>
+    Await.result(unfoldM(migrate(req.user, 1)), Duration.Inf)
+    Ok("Done!")
+  }
+
+  // Here's how it works:
+  // - query CAPI for all live explainers
+  // - insert each result in the DynamoDB preview and live stores
+  private def migrate(user: PandaUser)(pageNo: Int): Future[Unit] =
+    queryCapi(pageNo)
+      .flatMap(insertIntoDynamo(user))
+      .flatMap { totalPages: Int =>
+        if (pageNo < totalPages)
+          migrate(user)(pageNo + 1)
+        else
+          Future.successful(())
+      }
+
+  // Ask CAPI for a page of explainer atoms
+  private def queryCapi(pageNo: Int): Future[AtomsResponse] = {
+    val query = AtomsQuery().types("explainer").page(pageNo)
+    capiClient.getResponse(query)
+  }
+
+  // Publish atoms in the atom workshop datastores
+  private def insertIntoDynamo(user: PandaUser)(ar: AtomsResponse): Future[Int] = {
+    for {
+      result <- ar.results
+    } yield {
+      val atomFields = CreateAtomFields(
+        title = result.data match {
+          case a: AtomData.Explainer => Some(a.explainer.title)
+          case _ => None
+        },
+        defaultHtml = Some(result.defaultHtml),
+        commissioningDesks = result.commissioningDesks
+      )
+      val atomToCreate = AtomElementBuilders.buildDefaultAtom(AtomType.Explainer, user, Some(atomFields))
+      for {
+        atom <- atomWorkshopDB.createAtom(previewDataStore, AtomType.Explainer, user, atomToCreate)
+        updatedAtom <- atomWorkshopDB.publishAtom(publishedDataStore, user, updateTopLevelFields(atom, user, publish=true))
+        _ <- atomWorkshopDB.updateAtom(previewDataStore, updatedAtom)
+      } yield ()
+    }
+    
+    Future.successful(ar.pages)
+  }
+}

--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -75,7 +75,7 @@ class Migration(
 
   // Publish atoms in the atom workshop datastores
   private def insertIntoDynamo(user: PandaUser)(resp: JsValue): Future[Int] = {
-    (resp \ "results").asOpt[Array[JsValue]].foreach { results =>
+    (resp \ "response" \ "results").asOpt[Array[JsValue]].foreach { results =>
       for {
         result <- results
       } yield {
@@ -94,6 +94,6 @@ class Migration(
       }
     }
 
-    Future.successful((resp \ "pages").as[Int])
+    Future.successful((resp \ "response" \ "pages").as[Int])
   }
 }

--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -48,7 +48,7 @@ class Migration(
     signer.addIAMHeaders(headers = Map.empty, url = url).toSeq
 
   private def queryCapi(pageno: Int): Future[AtomsResponse] = {
-    val url = s"${Config.capiPreviewIAMUrl}/atoms?format=thrift&type=explainer&page=$pageno"
+    val url = s"${Config.capiPreviewIAMUrl}/atoms?format=thrift&types=explainer&page=$pageno"
     wsClient
       .url(url)
       .withHeaders(getHeaders(url): _*)

--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -1,25 +1,19 @@
 package controllers
 // ------------------------------------------------------------
 import cats.syntax.either._
-import com.gu.editorial.permissions.client.{Permission, PermissionGranted, PermissionsUser}
-import com.gu.pandomainauth.action.UserRequest
 import config.Config
 import db.AtomDataStores._
 import db.AtomWorkshopDBAPI
 import play.api.libs.concurrent.Execution.Implicits._
-import models._
+import models.CreateAtomFields
 import play.api.Logger
 import play.api.libs.ws.WSClient
 import play.api.mvc.{ActionBuilder, Controller, Request, Result}
 
 import services.AtomPublishers._
-import services.AtomWorkshopPermissionsProvider
-import util.AtomLogic._
 import util.AtomUpdateOperations._
 import util.AtomElementBuilders
-import play.api.mvc.Action
 
-import config.Config
 import com.gu.contentapi.client.IAMSigner
 import com.gu.contentapi.client.model.v1.AtomsResponse
 import com.gu.contentapi.client.thrift.ThriftDeserializer

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,8 @@ libraryDependencies ++= Seq(
   "io.circe"                 %% "circe-parser"                 % "0.7.0",
   "net.logstash.logback"     %  "logstash-logback-encoder"     % "4.2",
   "com.gu"                   %% "exact-target-lists"           % "0.1",
-  "com.gu"                   %% "content-api-client-aws"       % "0.2"
+  "com.gu"                   %% "content-api-client-aws"       % "0.2",
+  "com.gu"                   %% "content-api-client"           % "11.51"
 )
 
 resolvers ++= Seq(

--- a/conf/routes
+++ b/conf/routes
@@ -45,3 +45,6 @@ GET     /reindex-publish                         com.gu.atom.play.ReindexControl
 # Custom atom actions
 POST    /api/live/:atomType/:id/custom/notifications controllers.AtomActions.createNotificationList(atomType: String, id: String)
 DELETE  /api/live/:atomType/:id/custom/notifications controllers.AtomActions.deleteNotificationList(atomType: String, id: String)
+
+# Explainer migration
+GET     /migration/explainers                    controllers.Migration.migrateExplainers()


### PR DESCRIPTION
This is a one-off and will be reverted as soon as the migration has completed. Some explanation:

- @ajwl recently [added](https://github.com/guardian/atom-workshop/pull/198) the ability to edit explainers in atom workshop -- they used to be managed by another tool, which is going the way of the dodo
- while the UI part is done, the data store hasn't been hydrated with the necessary data, i.e. atom workshop uses a local database as a sort of index/cache/view over the whole of CAPI. 
- every action on an atom starts with a lookup into that database, but because there is currently nothing about explainers, trying to edit an explainer will fail.

In conclusion, we just need to query CAPI and populate that database with the data we get back, so that lookups won't fail and the UI loads correctly.

The migration script is a loop that queries CAPI for as long as there are pages of results and then yields to a function that inserts records in the database.