### PR TITLE
Explainers: Overwrite the data field

### DIFF
--- a/app/controllers/Migration.scala
+++ b/app/controllers/Migration.scala
@@ -18,6 +18,7 @@ import util.AtomElementBuilders
 import com.gu.contentapi.client.IAMSigner
 import com.gu.contentapi.client.model.v1.AtomsResponse
 import com.gu.contentatom.thrift.{AtomType, AtomData}
+import com.gu.contentatom.thrift.atom.explainer._
 import com.gu.pandomainauth.model.{User => PandaUser}
 
 import scala.concurrent.{Await, Future}
@@ -91,7 +92,13 @@ class Migration(
           defaultHtml = (result \ "defaultHtml").asOpt[String],
           commissioningDesks = (result \ "commissioningDesks").asOpt[List[String]].getOrElse(Nil)
         )
-        val atomToCreate = AtomElementBuilders.buildDefaultAtom(AtomType.Explainer, user, Some(atomFields))
+        val atomToCreate = AtomElementBuilders
+          .buildDefaultAtom(AtomType.Explainer, user, Some(atomFields))
+          .copy(data = AtomData.Explainer(ExplainerAtom(
+            atomFields.title.getOrElse("-"), 
+            (result \ "data" \ "explainer" \ "body").asOpt[String].getOrElse("-"), 
+            DisplayType.Flat
+          )))
         for {
           atom <- atomWorkshopDB.createAtom(previewDataStore, AtomType.Explainer, user, atomToCreate)
           updatedAtom <- atomWorkshopDB.publishAtom(publishedDataStore, user, updateTopLevelFields(atom, user, publish=true))


### PR DESCRIPTION
It turns out I misunderstood the logic in atom workshop: the data store holds _all_ the information it needs to display atoms, there is no query to CAPI. My previous PR assumed the opposite. The end result is that explainers in the database had all the surface information correct, but the body was missing (I did not see that in CODE because there is a default body).

In this change, we make sure the `data` field of the JSON payload is reified in an `AtomData` before the record is inserted in the database.