### PR TITLE
Simplify question/answer UX: only allow atoms as answers

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Answer.js
+++ b/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Answer.js
@@ -1,8 +1,6 @@
 import React, { PropTypes } from 'react';
 import {ManagedForm, ManagedField} from '../../../ManagedEditor';
 import FormFieldTextInput from '../../../FormFields/FormFieldTextInput';
-import SearchSelectBox from '../../../FormFields/SearchFields/SearchSelectBox';
-import _get from 'lodash/fp/get';
 
 export class StoryQuestionsAnswer extends React.Component {
   static propTypes = {

--- a/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Answer.js
+++ b/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Answer.js
@@ -19,26 +19,18 @@ export class StoryQuestionsAnswer extends React.Component {
 
   onUpdate = (answer) => {
     const answerWithType = Object.assign({}, answer, {
-      answerType: answer.answerType || "ATOM"
+      answerType: "ATOM"
     });
 
     this.props.onUpdateField(answerWithType);
   }
 
-  getPlaceholder = (answerType) => answerType === "CONTENT"
-    ? "e.g. world/2017/sep/21/an-explainer-article"
-    : "e.g. atom/guide/d12c3782-2d4b-4335-9701-830ac29c7d3b";
-
   render () {
-    const answerType = _get(this.props, "fieldValue.answerType", "ATOM");
-    const placeholder = this.getPlaceholder(answerType);
+    const placeholder = "e.g. atom/guide/d12c3782-2d4b-4335-9701-830ac29c7d3b";
 
     return (
       <div className="form__field form__field--nested">
         <ManagedForm data={this.props.fieldValue} updateData={this.onUpdate} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="storyquestionsEditor">
-          <ManagedField fieldLocation="answerType" name="Answer type" isRequired={true}>
-            <SearchSelectBox selectValues={["ATOM", "CONTENT"]} isRequired={true}/>
-          </ManagedField>
           <ManagedField fieldLocation="answerId" name="Answer ID" isRequired={true}>
             <FormFieldTextInput fieldPlaceholder={placeholder}/>
           </ManagedField>


### PR DESCRIPTION
First step in improving the UX of reader questions is to remove the ability to link an entire article as an answer to one question.

The reasoning is that, even if some questions lead to the writing of entire articles, the link between the two is not important to us in the grand scheme of things; especially, we're only interested in sending emails when the answer is a snippet.

Following that change, I will simplify the model and update our back-end to reflect that.