### PR TITLE
Enable rich text toolbar on text inputs for atoms

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
@@ -35,7 +35,7 @@ export class GuideItem extends React.Component {
             <FormFieldTextInput/>
           </ManagedField>
           <ManagedField fieldLocation="body" name="Body" isRequired={true}>
-            <FormFieldsScribeEditor showWordCount={true} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"}/>
+            <FormFieldsScribeEditor showWordCount={true} showToolbar={true} tooLongMsg={"Remember that snippets should be concise"}/>
           </ManagedField>
         </ManagedForm>
         <ShowErrors errors={this.props.fieldErrors}/>

--- a/public/js/components/AtomEdit/CustomEditors/ProfileFields/ProfileItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/ProfileFields/ProfileItem.js
@@ -35,7 +35,7 @@ export class ProfileItem extends React.Component {
             <FormFieldTextInput/>
           </ManagedField>
           <ManagedField fieldLocation="body" name="Body" isRequired={true}>
-            <FormFieldsScribeEditor showWordCount={true} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"} />
+            <FormFieldsScribeEditor showWordCount={true} showToolbar={true} tooLongMsg={"Remember that snippets should be concise"} />
           </ManagedField>
         </ManagedForm>
         <ShowErrors errors={this.props.fieldErrors}/>

--- a/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
@@ -31,7 +31,7 @@ export class QAItem extends React.Component {
       <div className="form__field">
         <ManagedForm data={value} updateData={this.updateItem} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="qaEditor">
           <ManagedField fieldLocation="body" name="Answer" isRequired={true}>
-            <FormFieldsScribeEditor showWordCount={true} suggestedLength={WordLimit} showToolbar={false} tooLongMsg={`You've exceeded the ${WordLimit} word limit for this atom.`}/>
+            <FormFieldsScribeEditor showWordCount={true} suggestedLength={WordLimit} showToolbar={true} tooLongMsg={`You've exceeded the ${WordLimit} word limit for this atom.`}/>
           </ManagedField>
         </ManagedForm>
       </div>

--- a/public/js/components/AtomEdit/CustomEditors/TimelineEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/TimelineEditor.js
@@ -20,7 +20,7 @@ export class TimelineEditor extends React.Component {
       <div className="form">
         <ManagedForm data={this.props.atom} updateData={this.props.onUpdate} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="timelineEditor">
           <ManagedField fieldLocation="data.timeline.description" name="Description - optional" isRequired={false}>
-            <FormFieldsScribeEditor showWordCount={true} suggestedLength={50} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"}/>
+            <FormFieldsScribeEditor showWordCount={true} suggestedLength={50} showToolbar={true} tooLongMsg={"Remember that snippets should be concise"}/>
           </ManagedField>
           <ManagedField fieldLocation="data.timeline.events" name="Events" customValidation={[checkItemsUnderWordCount]}>
             <FormFieldArrayWrapper>

--- a/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/TimelineFields/TimelineItem.js
@@ -122,7 +122,7 @@ export class TimelineItem extends React.Component {
             <FormFieldTextInput/>
           </ManagedField>
           <ManagedField fieldLocation="body" name="Body">
-            <FormFieldsScribeEditor showWordCount={true} showToolbar={false} tooLongMsg={"Remember that snippets should be concise"}/>
+            <FormFieldsScribeEditor showWordCount={true} showToolbar={true} tooLongMsg={"Remember that snippets should be concise"}/>
           </ManagedField>
         </ManagedForm>
           <ShowErrors errors={this.props.fieldErrors}/>


### PR DESCRIPTION
This will allow the text editing toolbar to be available on atom text input fields.
Allowing bold, italic and links to be used. 

It was requested by UX, we will inform Central production. 

Previously adding text to an atom looked like this:

![screen shot 2018-03-13 at 16 38 04](https://user-images.githubusercontent.com/10324129/37397658-12e48120-2774-11e8-992e-4a2fd60d7901.png)

Now it looks like:
![screen shot 2018-03-14 at 10 43 27](https://user-images.githubusercontent.com/10324129/37397859-9232fc68-2774-11e8-83b7-0e6076d99703.png)

