### PR TITLE
Allow multiple search suggestions

### DIFF
--- a/public/js/actions/SearchSuggestionsActions/cancel.js
+++ b/public/js/actions/SearchSuggestionsActions/cancel.js
@@ -1,11 +1,12 @@
-function cancelRequest() { 
+function cancelRequest(id) { 
   return { 
-    type: 'SEARCH_SUGGESTIONS_CANCEL'
+    type: 'SEARCH_SUGGESTIONS_CANCEL',
+    id
   };
 }
 
-export function cancel() {
+export function cancel(id) {
   return dispatch => {
-    dispatch(cancelRequest());
+    dispatch(cancelRequest(id));
   };
 }

--- a/public/js/actions/SearchSuggestionsActions/search.js
+++ b/public/js/actions/SearchSuggestionsActions/search.js
@@ -1,31 +1,34 @@
 import { searchAtoms } from '../../services/capi';
 
-function searchRequest(query) { 
+function searchRequest(id, query) { 
   return { 
     type: 'SEARCH_SUGGESTIONS_SEARCH_REQUEST',
-    query
+    query,
+    id
   };
 }
 
-function searchResponse(results) {
+function searchResponse(id, results) {
   return {
     type: 'SEARCH_SUGGESTIONS_SEARCH_RESPONSE',
-    results
+    results,
+    id
   };
 }
 
-function searchError(err) {
+function searchError(id, err) {
   return {
     type: 'SEARCH_SUGGESTIONS_SEARCH_ERROR',
-    err
+    err,
+    id
   };
 }
 
-export function search(query) {
+export function search(id, query) {
   return dispatch => {
-    dispatch(searchRequest(query));
+    dispatch(searchRequest(id, query));
     searchAtoms(query)
-      .then(results => dispatch(searchResponse(results)))
-      .catch(err => dispatch(searchError(err)));
+      .then(results => dispatch(searchResponse(id, results)))
+      .catch(err => dispatch(searchError(id, err)));
   };
 }

--- a/public/js/actions/SearchSuggestionsActions/update.js
+++ b/public/js/actions/SearchSuggestionsActions/update.js
@@ -1,12 +1,13 @@
-function updateRequest(queryStr) { 
+function updateRequest(id, queryStr) { 
   return { 
     type: 'SEARCH_SUGGESTIONS_UPDATE',
-    queryStr
+    queryStr,
+    id
   };
 }
 
-export function update(queryStr) {
+export function update(id, queryStr) {
   return dispatch => {
-    dispatch(updateRequest(queryStr));
+    dispatch(updateRequest(id, queryStr));
   };
 }

--- a/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Question.js
+++ b/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Question.js
@@ -29,6 +29,12 @@ export class StoryQuestionsQuestion extends React.Component {
       this.props.fieldValue.answers : []
   }
 
+  searchSuggestionsId = this.genKey()
+
+  genKey() {
+    return 'xxxxxxx'.replace(/x/g, () => (Math.random() * 36 | 0).toString(36));
+  }
+
   componentDidMount() {
     this.state.answers.forEach((answer, i) => {
     // eslint-disable-next-line
@@ -94,7 +100,7 @@ export class StoryQuestionsQuestion extends React.Component {
         </ManagedForm>
         <div className="atom__answers__header">
           <h5>Answers</h5>
-          <SearchSuggestions fieldPlaceholder="Search for snippets" filters={filters} onSelect={this.onSelect} />
+          <SearchSuggestions id={this.searchSuggestionsId} fieldPlaceholder="Search for snippets" filters={filters} onSelect={this.onSelect} />
         </div>
         <ul className="atom__answers">
           {this.state.answers.map((answer, i) => 

--- a/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Question.js
+++ b/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Question.js
@@ -98,6 +98,7 @@ export class StoryQuestionsQuestion extends React.Component {
             <FormFieldTextInput />
           </ManagedField>
         </ManagedForm>
+        <div><small>Answer by searching for snippets below</small></div>
         <div className="atom__answers__header">
           <h5>Answers</h5>
           <SearchSuggestions id={this.searchSuggestionsId} fieldPlaceholder="Search for snippets" filters={filters} onSelect={this.onSelect} />

--- a/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Question.js
+++ b/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/Question.js
@@ -32,7 +32,7 @@ export class StoryQuestionsQuestion extends React.Component {
   searchSuggestionsId = this.genKey()
 
   genKey() {
-    return 'xxxxxxx'.replace(/x/g, () => (Math.random() * 36 | 0).toString(36));
+    return Math.random().toString(36).substr(2);
   }
 
   componentDidMount() {

--- a/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/QuestionSet.js
+++ b/public/js/components/AtomEdit/CustomEditors/StoryQuestionFields/QuestionSet.js
@@ -38,7 +38,7 @@ export class StoryQuestionsQuestionSet extends React.Component {
     return (
       <ManagedForm data={value} updateData={this.updateQuestionSet} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="storyquestionsEditor">
         <ManagedField fieldLocation="questions" name="Questions" isRequired={true}>
-          <FormFieldArrayWrapper>
+          <FormFieldArrayWrapper fieldClass="atom__question">
             <StoryQuestionsQuestion />
           </FormFieldArrayWrapper>
         </ManagedField>

--- a/public/js/components/FormFields/SearchFields/SearchSuggestions.js
+++ b/public/js/components/FormFields/SearchFields/SearchSuggestions.js
@@ -56,8 +56,6 @@ class SearchSuggestions extends React.Component {
   }
 
   search = () => {
-    if (!this.props.queryStr.length > 2) return;
-
     const query = Object.assign({}, this.props.filters, {
       q: this.props.queryStr
     });
@@ -66,13 +64,17 @@ class SearchSuggestions extends React.Component {
   }
 
   renderResults() {
-    if (this.props.results) {
+    if (this.props.results && this.props.queryStr) {
       const results = this.props.results.map((result, i) =>
         <li onClick={this.onClick(i)} key={result.title}>{result.title}</li>
       );
+      const noresult = this.props.results.length === 0 ?
+        <li className="disabled">No snippet found matching the word "{this.props.queryStr}"</li> : null;
+
       return (
         <ul>
           {results}
+          {noresult}
         </ul>
       );
     }

--- a/public/js/components/FormFields/SearchFields/SearchSuggestions.js
+++ b/public/js/components/FormFields/SearchFields/SearchSuggestions.js
@@ -3,6 +3,7 @@ import SearchTextInput from './SearchTextInput';
 
 class SearchSuggestions extends React.Component {
   static propTypes = {
+    id: PropTypes.string.isRequired,
     placeholder: PropTypes.string,
     filters: PropTypes.object,
     onSelect: PropTypes.func.isRequired,
@@ -20,7 +21,7 @@ class SearchSuggestions extends React.Component {
   };
   
   onChange = (query) => {
-    this.props.searchActions.update(query);
+    this.props.searchActions.update(this.props.id, query);
     this.isTyping();
   }
 
@@ -31,7 +32,7 @@ class SearchSuggestions extends React.Component {
   }
 
   onClick = (i) => () => {
-    this.props.searchActions.cancel();
+    this.props.searchActions.cancel(this.props.id);
     this.props.onSelect(this.props.results[i]);
   }
 
@@ -41,7 +42,7 @@ class SearchSuggestions extends React.Component {
       this.setState({ timer: undefined });
     }
     
-    this.props.searchActions.cancel();
+    this.props.searchActions.cancel(this.props.id);
   }
 
   isTyping = () => {
@@ -61,7 +62,7 @@ class SearchSuggestions extends React.Component {
       q: this.props.queryStr
     });
 
-    this.props.searchActions.search(query);
+    this.props.searchActions.search(this.props.id, query);
   }
 
   renderResults() {
@@ -79,7 +80,7 @@ class SearchSuggestions extends React.Component {
 
   render() {
     return (
-      <div className="search-suggestions">
+      <div id={this.props.id} className="search-suggestions">
         <SearchTextInput fieldValue={this.props.queryStr} 
                          fieldPlaceholder={this.props.placeholder} 
                          onUpdateField={this.onChange} 
@@ -98,10 +99,13 @@ import * as cancel from '../../../actions/SearchSuggestionsActions/cancel.js';
 import * as search from '../../../actions/SearchSuggestionsActions/search.js';
 import * as update from '../../../actions/SearchSuggestionsActions/update.js';
 
-function mapStateToProps(state) {
-  return {
-    queryStr: state.searchSuggestions.queryStr,
-    results: state.searchSuggestions.results
+function mapStateToProps(state, props) {
+  return state.searchSuggestions[props.id] ? {
+    queryStr: state.searchSuggestions[props.id].queryStr,
+    results: state.searchSuggestions[props.id].results
+  } : {
+    queryStr: '',
+    results: []
   };
 }
 

--- a/public/js/components/FormFields/SearchFields/SearchTextInput.js
+++ b/public/js/components/FormFields/SearchFields/SearchTextInput.js
@@ -17,7 +17,7 @@ export default class SearchTextInput extends React.Component {
   }
 
   onKeyUp = (e) => {
-    this.props.onKeyUp(e.target.keyCode);
+    this.props.onKeyUp(e.keyCode);
   }
 
   render() {

--- a/public/js/reducers/searchSuggestionsReducer.js
+++ b/public/js/reducers/searchSuggestionsReducer.js
@@ -1,25 +1,33 @@
-export default function suggestions(state = { queryStr: '', query: null, results: null }, action) {
+export default function suggestions(state = {}, action) {
   switch(action.type) {
   case 'SEARCH_SUGGESTIONS_CANCEL':
-    return {
-      queryStr: '',
-      query: null,
-      results: null
-    };
+    return Object.assign({}, state, {
+      [action.id]: {
+        queryStr: '',
+        query: null,
+        results: null
+      }
+    });
 
   case 'SEARCH_SUGGESTIONS_UPDATE':
     return Object.assign({}, state, {
-      queryStr: action.queryStr
+      [action.id]: Object.assign({}, state[action.id], {
+        queryStr: action.queryStr
+      })
     });
 
   case 'SEARCH_SUGGESTIONS_SEARCH_REQUEST':
     return Object.assign({}, state, {
-      query: action.query
+      [action.id]: Object.assign({}, state[action.id], {
+        query: action.query
+      })
     });
 
   case 'SEARCH_SUGGESTIONS_SEARCH_RESPONSE':
     return Object.assign({}, state, {
-      results: action.results
+      [action.id]: Object.assign({}, state[action.id], {
+        results: action.results
+      })
     });
 
   default:

--- a/public/styles/abstracts/_variables.scss
+++ b/public/styles/abstracts/_variables.scss
@@ -79,6 +79,7 @@ $anchorColor: $cBlueLink;
 $brandColor: #06A2AB;
 $darkBrandColor: #0D6A71;
 $lightBrandColor: lighten($brandColor, 60);
+$disabledColor: $color300Grey;
 
 
 // Sizes

--- a/public/styles/components/_atom.scss
+++ b/public/styles/components/_atom.scss
@@ -32,3 +32,9 @@
   padding: 5px;
   border-bottom: 1px solid #ccc;
 }
+
+.atom__question {
+    & + & {
+        margin-top: 10px;
+    }
+}

--- a/public/styles/components/_search-suggestions.scss
+++ b/public/styles/components/_search-suggestions.scss
@@ -22,6 +22,8 @@
     list-style: none;
     margin: 0;
     padding: 0;
+    max-height: 220px;
+    overflow-y: auto;
 }
 
 .search-suggestions > ul > li {

--- a/public/styles/components/_search-suggestions.scss
+++ b/public/styles/components/_search-suggestions.scss
@@ -29,10 +29,15 @@
 .search-suggestions > ul > li {
     padding: .75rem 1rem;
     border-bottom: 1px solid #ddd;
-    cursor: pointer;
     
-    &:hover,
-    &:focus {
+    &:not(.disabled):hover,
+    &:not(.disabled):focus {
         background: lightblue;
+        cursor: pointer;
     }
+}
+
+.disabled {
+    color: $disabledColor;
+    font-style: italic;
 }


### PR DESCRIPTION
The global state currently holds properties for a single instance of `SearchSuggestions`, resulting in _all_ instances being hydrated with the same properties. If the users types something in one search field, all fields will display the same value and results. This is fun.

I've now made room for more that one instance. Each instance has an ID that is randomly generated—let's not be anal about that—and this ID is propagated into the global state.

Also a couple of display issues such as spacing and stuff like that.