### PR TITLE
Update riff-raff.yaml

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -14,7 +14,7 @@ deployments:
     parameters:
       amiTags:
         BuiltBy: amigo
-        Recipe: editorial-tools-xenial-java8
+        Recipe: editorial-tools-xenial-java8-deprecated
         AmigoStage: PROD
       amiEncrypted: true
       amiParameter: ImageId


### PR DESCRIPTION
In the move to `ssm`, we're removing the ssh-keys role from the AMIs that we use. The AMIgo recipe `editorial-tools-xenial-java8` no longer includes this role.

Explicitly use a deprecated AMIgo image, to make it obvious that this project needs updating.