### PR TITLE
Simplify target creation

### DIFF
--- a/public/js/components/AtomEmbed/CreateTargetForm.js
+++ b/public/js/components/AtomEmbed/CreateTargetForm.js
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react';
 import {createTarget} from '../../services/TargetingApi';
-import {addYears} from 'date-fns'
+import {addYears} from 'date-fns';
 
 import {ManagedForm, ManagedField} from '../ManagedEditor';
 import FormFieldTextInput from '../FormFields/FormFieldTextInput';

--- a/public/js/components/AtomEmbed/CreateTargetForm.js
+++ b/public/js/components/AtomEmbed/CreateTargetForm.js
@@ -1,10 +1,10 @@
 import React, {PropTypes} from 'react';
 import {createTarget} from '../../services/TargetingApi';
+import {addYears} from 'date-fns'
 
 import {ManagedForm, ManagedField} from '../ManagedEditor';
 import FormFieldTextInput from '../FormFields/FormFieldTextInput';
 import FormFieldTagPicker from '../FormFields/FormFieldTagPicker';
-import FormFieldDateInput from '../FormFields/FormFieldDateInput';
 import FormFieldArrayWrapper from '../FormFields/FormFieldArrayWrapper';
 
 
@@ -18,6 +18,7 @@ class CreateTargetForm extends React.Component {
   }
 
   state = {
+    pendingUpdate: false,
     creating: false,
     currentTarget: {},
     formHasError: true
@@ -43,7 +44,8 @@ class CreateTargetForm extends React.Component {
     });
 
     const target = Object.assign({}, this.state.currentTarget, {
-      url: this.props.atomPath
+      url: this.props.atomPath,
+      activeUntil: addYears(Date.now(), 50).valueOf()
     });
 
     createTarget(target).then((response) => {
@@ -59,6 +61,7 @@ class CreateTargetForm extends React.Component {
 
   updateCurrentTarget = (newTarget) => {
     this.setState({
+      pendingUpdate: true,
       currentTarget: newTarget
     });
   }
@@ -86,13 +89,10 @@ class CreateTargetForm extends React.Component {
               <FormFieldTagPicker/>
             </FormFieldArrayWrapper>
           </ManagedField>
-          <ManagedField fieldLocation="activeUntil" name="Active Until" isRequired={true}>
-            <FormFieldDateInput/>
-          </ManagedField>
         </ManagedForm>
         <button
-          className="btn"
-          disabled={this.state.formHasError || this.state.creating}
+          className="btn btn--green"
+          disabled={!this.state.pendingUpdate || this.state.formHasError || this.state.creating}
           onClick={this.createTarget}
           >
           {this.state.creating ? "Creating..." : "Create Suggestion"}

--- a/public/js/components/AtomEmbed/CurrentTargets.js
+++ b/public/js/components/AtomEmbed/CurrentTargets.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {atomPropType} from '../../constants/atomPropType';
 import {fetchTargetsForAtomPath, deleteTarget} from '../../services/TargetingApi';
-import distanceInWordsToNow from 'date-fns/distance_in_words_to_now';
 
 import CreateTargetForm from './CreateTargetForm';
 

--- a/public/js/components/AtomEmbed/CurrentTargets.js
+++ b/public/js/components/AtomEmbed/CurrentTargets.js
@@ -61,7 +61,6 @@ class CurrentTargets extends React.Component {
         <ul className="targeting__target__tags">
           {target.tagPaths.map((tagPath) => <li key={tagPath}>{tagPath}</li>)}
         </ul>
-        <div>Expires {distanceInWordsToNow(target.activeUntil, {addSuffix: true})} </div>
       </div>
     );
   }


### PR DESCRIPTION
We've had a few cases now of people struggling to create targets for their atoms.
It's consistently because they don't realise they need to click the 'Create Suggestion' button at the end. The UI is quite confusing and should really be rebuilt one day.

For now, as a quick fix I have tried to make it a bit clearer:
1. The 'Create Suggestion' button is disabled until a tag is added, then the button becomes active and green.
2. Removed the 'active until' date stuff, as Chris Moran says they don't need it and it takes up loads of space in the middle of the component. Instead it just sets the (mandatory) date to 50 years from now

### Before:
![picture 5](https://user-images.githubusercontent.com/1513454/40727893-d522abc0-6420-11e8-816f-d9b93964d2a8.png)


### After:
![picture 4](https://user-images.githubusercontent.com/1513454/40727907-dbe0a354-6420-11e8-838a-09cfd867d774.png)
