### PR TITLE
Fix delete button

### DIFF
--- a/app/models/Errors.scala
+++ b/app/models/Errors.scala
@@ -1,8 +1,11 @@
 package models
 
+import com.gu.contentatom.thrift.AtomType
+
 sealed abstract class AtomAPIError(val msg: String)
 
 case object InvalidAtomTypeError extends AtomAPIError("Atom type not valid - did you make a typo? Correct examples: 'cta', 'media")
+case class UnknownAtomError(atomType: AtomType, id: String) extends AtomAPIError(s"Unknown atom $atomType/$id")
 case object UnsupportedAtomTypeError extends AtomAPIError("Atom type not supported. Currently supported types: unknown")
 case object DeleteAtomFromPreviewError extends AtomAPIError("Could not delete atom from preview. Atom is live.")
 case class CreateAtomDynamoError(atomJson: String, message: String) extends AtomAPIError(s"Error thrown by Dynamo when attempting to create atom. JSON of atom: $atomJson, error message: $message")

--- a/app/util/AtomLogic.scala
+++ b/app/util/AtomLogic.scala
@@ -27,9 +27,6 @@ object AtomLogic {
     Either.cond(t.isDefined, t.get, InvalidAtomTypeError)
   }
 
-  def checkAtomCanBeDeletedFromPreview(responseFromLiveDatastore:Either[AtomAPIError, Atom]): Either[AtomAPIError, String] =
-    responseFromLiveDatastore.fold(_ => Right("Atom does not exist on live"), _ => Left(DeleteAtomFromPreviewError))
-
   def processException(exception: Exception): Either[AtomAPIError, Nothing] = {
     val atomApiError = exception match {
       case e: ParsingFailure => AtomJsonParsingError(e.message)

--- a/public/js/actions/AtomActions/deleteAtom.js
+++ b/public/js/actions/AtomActions/deleteAtom.js
@@ -31,7 +31,7 @@ function errorDeletingAtom(error) {
 export function deleteAtom(atom) {
   return dispatch => {
     dispatch(requestAtomDelete(atom));
-    return AtomsApi.DeleteAtom(atom)
+    return AtomsApi.deleteAtom(atom)
         .then(res => res.json())
         .then(atom => {
           dispatch(receiveAtomDelete(atom));

--- a/public/js/actions/AtomActions/deleteAtom.js
+++ b/public/js/actions/AtomActions/deleteAtom.js
@@ -1,19 +1,10 @@
 import AtomsApi from '../../services/AtomsApi';
 import {logError} from '../../util/logger';
 
-
 function requestAtomDelete(atom) {
   return {
     type:       'ATOM_DELETE_REQUEST',
     atom:        atom,
-    receivedAt: Date.now()
-  };
-}
-
-function receiveAtomDelete(atom) {
-  return {
-    type:       'ATOM_DELETE_RECEIVE',
-    atom:       atom,
     receivedAt: Date.now()
   };
 }
@@ -31,11 +22,13 @@ function errorDeletingAtom(error) {
 export function deleteAtom(atom) {
   return dispatch => {
     dispatch(requestAtomDelete(atom));
+
     return AtomsApi.deleteAtom(atom)
         .then(res => res.json())
-        .then(atom => {
-          dispatch(receiveAtomDelete(atom));
-        })
-        .catch(error => dispatch(errorDeletingAtom(error)));
+        .then(() =>
+          window.location.href = window.location.origin + '/'
+        ).catch(error =>
+          dispatch(errorDeletingAtom(error))
+        );
   };
 }

--- a/public/js/components/Header/DeleteAtom.js
+++ b/public/js/components/Header/DeleteAtom.js
@@ -31,14 +31,12 @@ export default class DeleteAtom extends React.Component {
     };
 
     return (
-      <li className="action-list__item">
-          <button
-            className="btn label__expired action-list__button"
-            onClick={doDelete}
-          >
-            {deleteMsg}
-          </button>
-      </li>
+      <button
+        className="btn btn--margin btn--red"
+        onClick={doDelete}
+      >
+        {deleteMsg}
+      </button>
     );
   }
 
@@ -46,6 +44,8 @@ export default class DeleteAtom extends React.Component {
     if (!this.showActions) {
       return false;
     }
+
+    return this.renderDelete();
 
     return (
       <div>

--- a/public/js/components/Header/DeleteAtom.js
+++ b/public/js/components/Header/DeleteAtom.js
@@ -46,13 +46,5 @@ export default class DeleteAtom extends React.Component {
     }
 
     return this.renderDelete();
-
-    return (
-      <div>
-        <ul className="action-list">
-          {this.renderDelete()}
-        </ul>
-      </div>
-    );
   }
 }

--- a/public/js/reducers/atomReducer.js
+++ b/public/js/reducers/atomReducer.js
@@ -25,9 +25,6 @@ export default function atom(state = null, action) {
         contentChangeDetails: action.atom.contentChangeDetails
       }) || false;
 
-    case 'ATOM_DELETE_RECEIVE':
-      return {} || false;
-
     case 'ATOM_CREATE_NOTIFICATION_RECEIVE':
       return action.atom || false;
 


### PR DESCRIPTION
Ronseal. I have refactored the server-side code to issue a takedown followed by delete for published content and simply a delete for unpublished. Finally I changed the frontend to redirect to the root, where previously it cleared the state and then barfed React render errors all over the place.

We should probably disallow deleting the atom until all usages have been removed.

![6cf8d28bd540fa4dd0b265b92e3b3ff9](https://user-images.githubusercontent.com/395805/41479584-91b7b056-70c3-11e8-88dc-ef4f1d0bad90.gif)
