### PR TITLE
Fix back button

### DIFF
--- a/public/js/reducers/queryParamsReducer.js
+++ b/public/js/reducers/queryParamsReducer.js
@@ -1,8 +1,16 @@
-export default function queryParams(state = {}, action) {
+import _isEmpty from 'lodash/isEmpty';
+import {searchParams} from '../constants/queryParams';
+
+export default function queryParams(state = searchParams, action) {
   switch (action.type) {
 
-    case 'QUERYPARAMS_UPDATE':
-      return action.queryParams;
+    case 'QUERYPARAMS_UPDATE': {
+      if(_isEmpty(action.queryParams)) {
+        return searchParams;
+      } else {
+        return action.queryParams;
+      }
+    }
 
     default:
       return state;


### PR DESCRIPTION
The back button was busted since it replaced the query parameters with an empty object rather than the default (leading to rendering errors in child components).

Now it doesn't! Success!