### PR TITLE
run in debug mode with a flag

### DIFF
--- a/scripts/client-dev.sh
+++ b/scripts/client-dev.sh
@@ -1,3 +1,18 @@
 #!/usr/bin/env bash
-yarn hmr &
-JS_ASSET_HOST="https://atomworkshop-assets.local.dev-gutools.co.uk/assets/" sbt "run 9050"
+
+IS_DEBUG=false
+for arg in "$@"
+do
+    if [ "$arg" == "--debug" ]; then
+        IS_DEBUG=true
+        shift
+    fi
+done
+
+export JS_ASSET_HOST="https://atomworkshop-assets.local.dev-gutools.co.uk/assets/"
+
+if [ "$IS_DEBUG" = true ] ; then
+    yarn hmr & sbt -jvm-debug 5055 "run 9050"
+else
+    yarn hmr & sbt "run 9050"
+fi


### PR DESCRIPTION
Recognise the `--debug` flag in `scripts/client-dev.sh` to start sbt in debug mode allowing you to interactively debug in your IDE

That is, `scripts/client-dev.sh --debug` and start debugging on port `5055`.