### PR TITLE
show a message if not authed against Visuals Chart Tool

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/ChartEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/ChartEditor.js
@@ -17,6 +17,16 @@ export class ChartEditor extends React.Component {
     modalOpen: false
   };
 
+  constructor(props) {
+    super(props);
+
+    const {visualsUrl} = this.props.config;
+
+    fetch(visualsUrl)
+      .then(res => this.setState({visualsAuthenticated: res.status >= 200 && res.status < 300}))
+      .catch(() => this.setState({visualsAuthenticated: false}));
+  }
+
   toggleModal = (e) => {
     e.preventDefault();
     if (this.state.modalOpen) {
@@ -61,12 +71,27 @@ export class ChartEditor extends React.Component {
     this.closeModal();
   };
 
+  renderVisualsApp() {
+    const {visualsUrl} = this.props.config;
+
+    if (this.state.visualsAuthenticated) {
+      const iFrameSrc = (this.props.config.stage === "PROD") ? `${visualsUrl}/basichartool`: `${visualsUrl}`;
+      return (
+          <iframe className="chartembedder__modal" src={`${iFrameSrc}?atom=${this.props.atom.id}`} />
+      );
+    } else {
+      return (
+        <div className="chartembedder__modal chartembedder__no-auth">
+          ⛔️ <a href={visualsUrl} target="_blank" rel="noreferrer noopener" onClick={this.closeModal}>Click here to login to the Chart Tool (then come back!)</a>
+        </div>
+      );
+    }
+  }
+
   render () {
     const chartHtml = {
       __html: this.props.atom.defaultHtml
     };
-
-    const iFrameSrc = (this.props.config.stage === "PROD") ? `${this.props.config.visualsUrl}/basichartool`: `${this.props.config.visualsUrl}`;
 
     return (
       <div>
@@ -74,7 +99,7 @@ export class ChartEditor extends React.Component {
           Edit Chart
         </button>
         <Modal isOpen={this.state.modalOpen} dismiss={this.closeModal}>
-          <iframe className="chartembedder__modal" src={`${iFrameSrc}?atom=${this.props.atom.id}`} />
+          {this.renderVisualsApp()}
         </Modal>
         <div dangerouslySetInnerHTML={chartHtml}></div>
       </div>

--- a/public/styles/components/_chart.scss
+++ b/public/styles/components/_chart.scss
@@ -3,3 +3,9 @@
     width: 100%;
     background-color: $cWhite; 
 }
+
+.chartembedder__no-auth {
+    display:flex;
+    justify-content:center;
+    align-items:center;
+}


### PR DESCRIPTION
Sadly we can't use the auth flow of the Visuals Chart Tool within the iframe as Google Auth complains `Refused to display ... in a frame because it set 'X-Frame-Options' to 'sameorigin'.`

This is a cheat to provide a slightly better user experience when not authed.

# Before
![before](https://user-images.githubusercontent.com/836140/46968899-6f983b00-d0ac-11e8-94f9-05700048cbf0.gif)

# After
![after](https://user-images.githubusercontent.com/836140/46968927-7e7eed80-d0ac-11e8-82e7-5765e9287493.gif)
