### PR TITLE
make request to visuals with a cookie

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/ChartEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/ChartEditor.js
@@ -22,7 +22,7 @@ export class ChartEditor extends React.Component {
 
     const {visualsUrl} = this.props.config;
 
-    fetch(visualsUrl)
+    fetch(visualsUrl, {credentials: "include"})
       .then(res => this.setState({visualsAuthenticated: res.status >= 200 && res.status < 300}))
       .catch(() => this.setState({visualsAuthenticated: false}));
   }


### PR DESCRIPTION
We're making a call to visuals and checking the response code as a horrible way to check if we're authed.

It would help if we [send our cookie along with the request](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Sending_a_request_with_credentials_included)...

relates to #219 