### PR TITLE
clearer messaging

### DIFF
--- a/public/js/components/AtomEmbed/AtomEmbed.js
+++ b/public/js/components/AtomEmbed/AtomEmbed.js
@@ -86,7 +86,7 @@ class AtomEmbed extends React.Component {
           <div className="form__row">
             <Link to={`/atoms/${this.props.atom.atomType}/${this.props.atom.id}/stats`}
                   className="atom-list__link">
-              Where can I embed this atom?
+              Where has this atom been used?
             </Link>
           </div>
         </div>


### PR DESCRIPTION
This link takes you to a page that lists where the atom is currently embedded. The current wording implies "these are the places we recommend you add this atom to".