### PR TITLE
AUDIO FIX FIX: Rename title to kicker

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/AudioEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/AudioEditor.js
@@ -17,7 +17,7 @@ export class AudioEditor extends React.Component {
     return (
       <div>
         <ManagedForm formName="audioEditor" data={this.props.atom} updateData={this.props.onUpdate} onFormErrorsUpdate={this.props.onFormErrorsUpdate} >
-          <ManagedField fieldLocation="data.audio.title" name="Title" isRequired={true}>
+          <ManagedField fieldLocation="data.audio.kicker" name="Kicker (title)" isRequired={true}>
             <FormFieldTextInput />
           </ManagedField>
           <ManagedField fieldLocation="data.audio.trackUrl" name="Track url" isRequired={true} customValidation={[isHttpsUrl]}>


### PR DESCRIPTION
One of the properties has the wrong name. Changed to match the scala stuff 

`title` to `kicker`