### PR TITLE
Audio Atom: Allow users to fetch data from Capi audio pages

### DIFF
--- a/public/js/actions/AtomActions/getAudioPageData.js
+++ b/public/js/actions/AtomActions/getAudioPageData.js
@@ -1,0 +1,82 @@
+import {fetchPageData, getByPath} from '../../services/capi';
+import {logError} from '../../util/logger';
+import {updateAtom} from "./updateAtom";
+
+
+export function getAudioPageData (url, atom) {
+  const path = new URL(url).pathname;
+  const pathNoLeadingSlash = path.substring(1);
+
+  return dispatch => {
+    dispatch(requestAudioPageData());
+    return getByPath(pathNoLeadingSlash)
+      .then(res => {
+        dispatch(receiveAudioPageData(res));
+        const updatedAtom = addDataToAtom(res, atom);
+        dispatch(updateAtom(updatedAtom));
+        return res;
+      })
+      .catch(error => dispatch(errorReceivingAudioPageData(error)))
+  }
+}
+
+function extractFields (audioPage) {
+  let audioEl = audioPage.elements.find(el => el.type === "audio");
+  let seriesTag = audioPage.tags.find(tag => tag.type === "series" && tag.podcast);
+  let {subscriptionUrl, googlePodcastsUrl, spotifyUrl} = seriesTag.podcast;
+  let durationSeconds = parseInt(audioEl.assets[0].typeData.durationMinutes) * 60 + parseInt(audioEl.assets[0].typeData.durationSeconds);
+
+  return {
+    contentId: audioEl.id,
+    trackUrl: audioEl.assets[0].file,
+    duration: durationSeconds,
+    kicker: seriesTag.webTitle,
+    subscriptionLinks: {
+      apple: subscriptionUrl,
+      google: googlePodcastsUrl,
+      spotify: spotifyUrl
+    }
+  }
+}
+
+function addDataToAtom (audioPage, atom) {
+  let {contentId, trackUrl, duration, kicker, subscriptionLinks} = extractFields(audioPage);
+  let atomData = {
+    data: {
+      audio: {
+        kicker,
+        contentId,
+        duration,
+        trackUrl,
+        subscriptionLinks,
+        coverUrl: "https://uploads.guim.co.uk/2018/10/18/Podcast_ident_3000px.jpg",
+      }
+    }
+  };
+  let newAtom = Object.assign({}, atom, atomData);
+  return newAtom;
+}
+
+function requestAudioPageData () {
+  return {
+    type: 'REQUEST_AUDIO_PAGE_DATA',
+    audioPageUrl: ''
+  }
+}
+
+function receiveAudioPageData (content) {
+  return {
+    type: 'RECEIVE_AUDIO_PAGE_DATA',
+    audioPageData: { content },
+    message: `You selected: ${content.webTitle}`
+  }
+}
+
+function errorReceivingAudioPageData (error) {
+  logError(error);
+  return {
+    type: 'ERROR_RECEIVING_AUDIO_PAGE_DATA',
+    message: 'Could not get data from the url above, please double check it or report the problem',
+    error: `${error.status}: ${error.statusText}`
+  }
+}

--- a/public/js/actions/AtomActions/getAudioPageData.js
+++ b/public/js/actions/AtomActions/getAudioPageData.js
@@ -30,7 +30,6 @@ function requestAudioPageData () {
 function receiveAudioPageData (content) {
   return {
     type: 'RECEIVE_AUDIO_PAGE_DATA',
-    audioPageData: { content },
     message: `You selected: ${content.webTitle}`
   };
 }

--- a/public/js/actions/AtomActions/getAudioPageData.js
+++ b/public/js/actions/AtomActions/getAudioPageData.js
@@ -1,4 +1,4 @@
-import {fetchPageData, getByPath} from '../../services/capi';
+import {getByPath} from '../../services/capi';
 import {logError} from '../../util/logger';
 import {updateAtom} from "./updateAtom";
 
@@ -16,9 +16,34 @@ export function getAudioPageData (url, atom) {
         dispatch(updateAtom(updatedAtom));
         return res;
       })
-      .catch(error => dispatch(errorReceivingAudioPageData(error)))
-  }
+      .catch(error => dispatch(errorReceivingAudioPageData(error)));
+  };
 }
+
+function requestAudioPageData () {
+  return {
+    type: 'REQUEST_AUDIO_PAGE_DATA',
+    audioPageUrl: ''
+  };
+}
+
+function receiveAudioPageData (content) {
+  return {
+    type: 'RECEIVE_AUDIO_PAGE_DATA',
+    audioPageData: { content },
+    message: `You selected: ${content.webTitle}`
+  };
+}
+
+function errorReceivingAudioPageData (error) {
+  logError(error);
+  return {
+    type: 'ERROR_RECEIVING_AUDIO_PAGE_DATA',
+    message: 'Could not get data from the url above, please double check it or report the problem',
+    error: `${error.status}: ${error.statusText}`
+  };
+}
+
 
 function extractFields (audioPage) {
   let audioEl = audioPage.elements.find(el => el.type === "audio");
@@ -38,7 +63,7 @@ function extractFields (audioPage) {
       apple: subscriptionUrl,
       google: googlePodcastsUrl,
       spotify: spotifyUrl
-    }
+    };
   }
 
   return {
@@ -48,7 +73,7 @@ function extractFields (audioPage) {
     kicker: seriesTag.webTitle,
     coverUrl: storyImage,
     subscriptionLinks
-  }
+  };
 }
 
 function addDataToAtom (audioPage, atom) {
@@ -66,28 +91,4 @@ function addDataToAtom (audioPage, atom) {
     }
   };
   return Object.assign({}, atom, atomData);
-}
-
-function requestAudioPageData () {
-  return {
-    type: 'REQUEST_AUDIO_PAGE_DATA',
-    audioPageUrl: ''
-  }
-}
-
-function receiveAudioPageData (content) {
-  return {
-    type: 'RECEIVE_AUDIO_PAGE_DATA',
-    audioPageData: { content },
-    message: `You selected: ${content.webTitle}`
-  }
-}
-
-function errorReceivingAudioPageData (error) {
-  logError(error);
-  return {
-    type: 'ERROR_RECEIVING_AUDIO_PAGE_DATA',
-    message: 'Could not get data from the url above, please double check it or report the problem',
-    error: `${error.status}: ${error.statusText}`
-  }
 }

--- a/public/js/components/AtomEdit/CustomEditors/AudioEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/AudioEditor.js
@@ -1,9 +1,6 @@
 import React, { PropTypes } from 'react';
 import {atomPropType} from '../../../constants/atomPropType';
-import {ManagedField, ManagedForm} from "../../ManagedEditor";
-import FormFieldTextInput from "../../FormFields/FormFieldTextInput";
-import FormFieldNumericInput from "../../FormFields/FormFieldNumericInput";
-import {isHttpsUrl} from "../../../util/validators";
+import AutomaticDataFetch from "./AudioFields/AutomaticDataFetch";
 
 export class AudioEditor extends React.Component {
 
@@ -16,34 +13,7 @@ export class AudioEditor extends React.Component {
   render () {
     return (
       <div>
-        <ManagedForm formName="audioEditor" data={this.props.atom} updateData={this.props.onUpdate} onFormErrorsUpdate={this.props.onFormErrorsUpdate} >
-          <ManagedField fieldLocation="data.audio.kicker" name="Kicker (title)" isRequired={true}>
-            <FormFieldTextInput />
-          </ManagedField>
-          <ManagedField fieldLocation="data.audio.trackUrl" name="Track url" isRequired={true} customValidation={[isHttpsUrl]}>
-            <FormFieldTextInput />
-          </ManagedField>
-          <ManagedField fieldLocation="data.audio.contentId" name="Content ID" isRequired={true}>
-            <FormFieldTextInput/>
-          </ManagedField>
-          <ManagedField fieldLocation="data.audio.duration" name="Duration (seconds)" isRequired={true}>
-            <FormFieldNumericInput/>
-          </ManagedField>
-          <ManagedField fieldLocation="data.audio.coverUrl" name="Image url" isRequired={true} customValidation={[isHttpsUrl]}>
-            <FormFieldTextInput />
-          </ManagedField>
-
-          <ManagedField fieldLocation="data.audio.subscriptionLinks.apple" name="Subscription: Apple Podcasts" customValidation={[isHttpsUrl]}>
-            <FormFieldTextInput/>
-          </ManagedField>
-          <ManagedField fieldLocation="data.audio.subscriptionLinks.google" name="Subscription: Google Podcasts" customValidation={[isHttpsUrl]}>
-            <FormFieldTextInput/>
-          </ManagedField>
-          <ManagedField fieldLocation="data.audio.subscriptionLinks.spotify" name="Subscription: Spotify" customValidation={[isHttpsUrl]}>
-            <FormFieldTextInput/>
-          </ManagedField>
-
-        </ManagedForm>
+        <AutomaticDataFetch onUpdate={this.props.onUpdate} atom={this.props.atom} />
       </div>
     );
   }

--- a/public/js/components/AtomEdit/CustomEditors/AudioFields/AutomaticDataFetch.js
+++ b/public/js/components/AtomEdit/CustomEditors/AudioFields/AutomaticDataFetch.js
@@ -56,7 +56,7 @@ class AutomaticDataFetch extends React.Component {
 
         <div className="audio--manual-selection-box">
           <h3>Or manually add the data in here</h3>
-          <ManualDataInput atom={this.props.atom} onUpdate={this.props.onUpdate} audioPageData={this.props.audioPageData}/>
+          <ManualDataInput atom={this.props.atom} onUpdate={this.props.onUpdate} />
         </div>
       </div>
     );

--- a/public/js/components/AtomEdit/CustomEditors/AudioFields/AutomaticDataFetch.js
+++ b/public/js/components/AtomEdit/CustomEditors/AudioFields/AutomaticDataFetch.js
@@ -1,6 +1,13 @@
 import React, { PropTypes } from 'react';
 import {ManualDataInput} from "./ManualDataInput";
 
+//REDUX CONNECTIONS
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { getAudioPageData } from '../../../../actions/AtomActions/getAudioPageData.js';
+import {atomPropType} from "../../../../constants/atomPropType";
+
+
 class AutomaticDataFetch extends React.Component {
 
   static propTypes = {
@@ -27,7 +34,7 @@ class AutomaticDataFetch extends React.Component {
   }
 
   checkUrlIsAudioPage (url) {
-    return url.startsWith('https://www.theguardian.com/news/audio');
+    return url.startsWith('https://www.theguardian.com') && url.includes('audio');
   }
 
   handleChange (e) {
@@ -42,7 +49,7 @@ class AutomaticDataFetch extends React.Component {
           <label>Paste the url of a Guardian audio page</label>
           <input id="audio-url" className="form__field" type="text" value={this.state.audioPageUrl} onChange={this.handleChange.bind(this)}></input>
           <button type="button" className="form__btn-heading__btn" onClick={this.getAudioDataFromCapi.bind(this)}>Get values</button>
-          <p>{ this.state.urlError }</p>
+          { this.state.urlError ? (<p>{ this.state.urlError }</p>) : null }
           <p>{ this.props.audioPageData ? this.props.audioPageData.message : "" }</p>
 
         </div>
@@ -56,11 +63,7 @@ class AutomaticDataFetch extends React.Component {
   }
 }
 
-//REDUX CONNECTIONS
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import { getAudioPageData } from '../../../../actions/AtomActions/getAudioPageData.js';
-import {atomPropType} from "../../../../constants/atomPropType";
+/* REDUX FUNCTIONS */
 
 function mapStateToProps(state) {
   return {

--- a/public/js/components/AtomEdit/CustomEditors/AudioFields/AutomaticDataFetch.js
+++ b/public/js/components/AtomEdit/CustomEditors/AudioFields/AutomaticDataFetch.js
@@ -27,9 +27,9 @@ class AutomaticDataFetch extends React.Component {
   getAudioDataFromCapi () {
     if(this.checkUrlIsAudioPage(this.state.audioPageUrl)){
       this.props.getAudioPageData(this.state.audioPageUrl, this.props.atom);
-      this.setState({urlError: ''})
+      this.setState({urlError: ''});
     } else {
-      this.setState({urlError: 'The url is not a valid Guardian audio page'})
+      this.setState({urlError: 'The url is not a valid Guardian audio page'});
     }
   }
 
@@ -59,7 +59,7 @@ class AutomaticDataFetch extends React.Component {
           <ManualDataInput atom={this.props.atom} onUpdate={this.props.onUpdate} audioPageData={this.props.audioPageData}/>
         </div>
       </div>
-    )
+    );
   }
 }
 

--- a/public/js/components/AtomEdit/CustomEditors/AudioFields/AutomaticDataFetch.js
+++ b/public/js/components/AtomEdit/CustomEditors/AudioFields/AutomaticDataFetch.js
@@ -1,0 +1,80 @@
+import React, { PropTypes } from 'react';
+import {ManualDataInput} from "./ManualDataInput";
+
+class AutomaticDataFetch extends React.Component {
+
+  static propTypes = {
+    getAudioPageData: PropTypes.func,
+    onUpdate: PropTypes.func.isRequired,
+    onFormErrorsUpdate: PropTypes.func,
+    error: PropTypes.string,
+    audioPageData: PropTypes.object,
+    atom: atomPropType.isRequired,
+  };
+
+  state = {
+    audioPageUrl: '',
+    urlError: ''
+  };
+
+  getAudioDataFromCapi () {
+    if(this.checkUrlIsAudioPage(this.state.audioPageUrl)){
+      this.props.getAudioPageData(this.state.audioPageUrl, this.props.atom);
+      this.setState({urlError: ''})
+    } else {
+      this.setState({urlError: 'The url is not a valid Guardian audio page'})
+    }
+  }
+
+  checkUrlIsAudioPage (url) {
+    return url.startsWith('https://www.theguardian.com/news/audio');
+  }
+
+  handleChange (e) {
+    this.setState({audioPageUrl: e.target.value});
+  }
+
+  render () {
+    return (
+      <div>
+        <div className="audio--automatic-selection-box">
+          <h3>Get audio data automatically</h3>
+          <label>Paste the url of a Guardian audio page</label>
+          <input id="audio-url" className="form__field" type="text" value={this.state.audioPageUrl} onChange={this.handleChange.bind(this)}></input>
+          <button type="button" className="form__btn-heading__btn" onClick={this.getAudioDataFromCapi.bind(this)}>Get values</button>
+          <p>{ this.state.urlError }</p>
+          <p>{ this.props.audioPageData ? this.props.audioPageData.message : "" }</p>
+
+        </div>
+
+        <div className="audio--manual-selection-box">
+          <h3>Or manually add the data in here</h3>
+          <ManualDataInput atom={this.props.atom} onUpdate={this.props.onUpdate} audioPageData={this.props.audioPageData}/>
+        </div>
+      </div>
+    )
+  }
+}
+
+//REDUX CONNECTIONS
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { getAudioPageData } from '../../../../actions/AtomActions/getAudioPageData.js';
+import {atomPropType} from "../../../../constants/atomPropType";
+
+function mapStateToProps(state) {
+  return {
+    config: state.config,
+    audioPageUrl: state.audioPageUrl,
+    audioPageData: state.audioPageData,
+    atom: state.atom
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    getAudioPageData: bindActionCreators(getAudioPageData, dispatch)
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(AutomaticDataFetch);

--- a/public/js/components/AtomEdit/CustomEditors/AudioFields/ManualDataInput.js
+++ b/public/js/components/AtomEdit/CustomEditors/AudioFields/ManualDataInput.js
@@ -46,8 +46,8 @@ export class ManualDataInput extends React.Component {
           </ManagedField>
         </ManagedForm>
       </div>
-    )
-  };
+    );
+  }
 }
 
 

--- a/public/js/components/AtomEdit/CustomEditors/AudioFields/ManualDataInput.js
+++ b/public/js/components/AtomEdit/CustomEditors/AudioFields/ManualDataInput.js
@@ -1,0 +1,53 @@
+import React, { PropTypes } from 'react';
+import {ManagedForm, ManagedField} from '../../../ManagedEditor';
+import FormFieldTextInput from '../../../FormFields/FormFieldTextInput';
+import FormFieldNumericInput from '../../../FormFields/FormFieldNumericInput';
+import {isHttpsUrl} from "../../../../util/validators";
+import {atomPropType} from "../../../../constants/atomPropType";
+
+
+export class ManualDataInput extends React.Component {
+
+  static propTypes = {
+    atom: atomPropType.isRequired,
+    onUpdate: PropTypes.func.isRequired,
+    onFormErrorsUpdate: PropTypes.func,
+    audioPageData: PropTypes.object
+  };
+
+  render () {
+    return (
+      <div>
+        <ManagedForm formName="audioEditor" data={this.props.atom} updateData={this.props.onUpdate}>
+          <ManagedField fieldLocation="data.audio.kicker" name="Label (eg name of podcast series)" isRequired={true}>
+            <FormFieldTextInput />
+          </ManagedField>
+          <ManagedField fieldLocation="data.audio.trackUrl" name="Track url" isRequired={true} customValidation={[isHttpsUrl]}>
+            <FormFieldTextInput />
+          </ManagedField>
+          <ManagedField fieldLocation="data.audio.contentId" name="Audio ID" isRequired={true}>
+            <FormFieldTextInput />
+          </ManagedField>
+          <ManagedField fieldLocation="data.audio.duration" name="Duration (seconds)" isRequired={true}>
+            <FormFieldNumericInput  />
+          </ManagedField>
+          <ManagedField fieldLocation="data.audio.coverUrl" name="Image url" isRequired={true} customValidation={[isHttpsUrl]}>
+            <FormFieldTextInput  />
+          </ManagedField>
+
+          <ManagedField fieldLocation="data.audio.subscriptionLinks.apple" name="Subscription: Apple Podcasts" customValidation={[isHttpsUrl]}>
+            <FormFieldTextInput />
+          </ManagedField>
+          <ManagedField fieldLocation="data.audio.subscriptionLinks.google" name="Subscription: Google Podcasts" customValidation={[isHttpsUrl]}>
+            <FormFieldTextInput />
+          </ManagedField>
+          <ManagedField fieldLocation="data.audio.subscriptionLinks.spotify" name="Subscription: Spotify" customValidation={[isHttpsUrl]}>
+            <FormFieldTextInput />
+          </ManagedField>
+        </ManagedForm>
+      </div>
+    )
+  };
+}
+
+

--- a/public/js/components/AtomEdit/CustomEditors/AudioFields/ManualDataInput.js
+++ b/public/js/components/AtomEdit/CustomEditors/AudioFields/ManualDataInput.js
@@ -10,9 +10,7 @@ export class ManualDataInput extends React.Component {
 
   static propTypes = {
     atom: atomPropType.isRequired,
-    onUpdate: PropTypes.func.isRequired,
-    onFormErrorsUpdate: PropTypes.func,
-    audioPageData: PropTypes.object
+    onUpdate: PropTypes.func.isRequired
   };
 
   render () {

--- a/public/js/reducers/audioPageDataReducer.js
+++ b/public/js/reducers/audioPageDataReducer.js
@@ -10,7 +10,6 @@ export default function audioPageData (state = null, action) {
     }
 
     case 'RECEIVE_AUDIO_PAGE_DATA': {
-      console.log("receive state happened action.audioPageData", action.audioPageData);
       const newState = {
         message: action.message,
         audioPageData: action.audioPageData.content

--- a/public/js/reducers/audioPageDataReducer.js
+++ b/public/js/reducers/audioPageDataReducer.js
@@ -1,0 +1,34 @@
+export default function audioPageData (state = null, action) {
+  switch (action.type) {
+
+    case 'REQUEST_AUDIO_PAGE_DATA': {
+      const newState = {
+        error: null,
+        message: ''
+      };
+      return Object.assign({}, state, newState);
+    }
+
+    case 'RECEIVE_AUDIO_PAGE_DATA': {
+      console.log("receive state happened action.audioPageData", action.audioPageData);
+      const newState = {
+        message: action.message,
+        audioPageData: action.audioPageData.content
+      };
+      return Object.assign({}, state, newState);
+    }
+
+    case 'ERROR_RECEIVING_AUDIO_PAGE_DATA': {
+      const newState = {
+        error: action.error,
+        audioPageData: {},
+        message: action.message
+      };
+      return Object.assign({}, state, newState);
+    }
+
+    default:
+      return state;
+  }
+}
+

--- a/public/js/reducers/rootReducer.js
+++ b/public/js/reducers/rootReducer.js
@@ -16,6 +16,7 @@ import queryParams from '../reducers/queryParamsReducer';
 import workflow from '../reducers/workflowReducer';
 import commonsDivisions from '../reducers/commonsDivisionsReducer';
 import searchSuggestions from '../reducers/searchSuggestionsReducer';
+import audioPageData from './audioPageDataReducer';
 import {routerReducer} from 'react-router-redux';
 
 export const rootReducer = combineReducers({
@@ -35,5 +36,6 @@ export const rootReducer = combineReducers({
   workflow,
   commonsDivisions,
   searchSuggestions,
+  audioPageData,
   routing: routerReducer
 });

--- a/public/js/services/capi.js
+++ b/public/js/services/capi.js
@@ -56,7 +56,7 @@ export const fetchAtomUsages = (atomType, atomId) => {
 
 export const getByPath = (path) => {
   return pandaFetch(
-    `/support/previewCapi/${path}?show-fields=all`,
+    `/support/previewCapi/${path}?show-fields=all&show-elements=all&show-tags=all`,
     {
       method: 'get',
       credentials: 'same-origin'

--- a/public/styles/components/_audio.scss
+++ b/public/styles/components/_audio.scss
@@ -1,0 +1,7 @@
+.audio--automatic-selection-box {
+  padding: .5em 0 1.5em 0;
+
+  .form__btn-heading__btn {
+    margin-left: 0;
+  }
+}

--- a/public/styles/main.scss
+++ b/public/styles/main.scss
@@ -43,4 +43,5 @@
 'components/suggestions',
 'components/commons-divisions',
 'components/search-suggestions',
-'components/chart';
+'components/chart',
+'components/audio';


### PR DESCRIPTION
This allows users to grab all the information they need for a Guardian Podcast file from the page where it is hosted. eg: `https://www.theguardian.com/news/audio/2019/feb/05/is-climate-change-way-worse-than-we-realise-today-in-focus-podcast`

## Why? 
The initial use of the audio atom is for podcast promotion. This allows the user to get all the podcast information quickly from a published guardian audio page. 

## How it works 
Users can now paste in a url when they create an audio atom. 

![screen shot 2019-02-05 at 15 42 09](https://user-images.githubusercontent.com/10324129/52285862-0a1fd100-295f-11e9-914c-17d548281a5d.png)

Hitting "Get Values" populates the form with data from the page: 

![screen shot 2019-02-05 at 15 43 10](https://user-images.githubusercontent.com/10324129/52285905-1e63ce00-295f-11e9-90a3-1c485791786c.png)

If the url isn't a guardian audio page, this error shows up: 
![screen shot 2019-02-05 at 15 42 27](https://user-images.githubusercontent.com/10324129/52285956-39ced900-295f-11e9-9015-07bc9d1486fa.png)

If the url is slightly wrong, or we are unable to fetch data for the page. This error shows up:

![screen shot 2019-02-05 at 15 42 52](https://user-images.githubusercontent.com/10324129/52286011-523ef380-295f-11e9-93a2-9e1dd0140f4d.png)

## To Test 
In order to pull in audio pages from CAPI Prod. You need to set your config file to point to it:
`vi ~/.configuration-magic/atom-workshop.conf`
`previewIAMUrl=<INTERNAL PROD CAPI URL>`

## Notes / Questions
* My first pull request with Redux. Am i using it optimally? 
* Subscription links don't appear to save, but since we don't need them for MVP, will deal with this in a future pr. 

