### PR TITLE
Bump thrift-related dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.0"
 scalaVersion := "2.11.12"
 
 lazy val awsVersion = "1.11.8"
-lazy val atomLibVersion = "1.1.20"
+lazy val atomLibVersion = "1.2.0"
 
 libraryDependencies ++= Seq(
   ws,
@@ -16,14 +16,14 @@ libraryDependencies ++= Seq(
   "com.gu"                   %% "atom-publisher-lib"           % atomLibVersion,
   "com.gu"                   %% "editorial-permissions-client" % "0.7",
   "com.gu"                   %% "configuration-magic-core"     % "1.3.0",
-  "com.gu"                   %% "fezziwig"                     % "0.7",
+  "com.gu"                   %% "fezziwig"                     % "1.1",
   "com.gu"                   %  "kinesis-logback-appender"     % "1.3.0",
   "com.gu"                   %% "pan-domain-auth-play_2-5"     % "0.4.1",
-  "io.circe"                 %% "circe-parser"                 % "0.7.0",
+  "io.circe"                 %% "circe-parser"                 % "0.11.0",
   "net.logstash.logback"     %  "logstash-logback-encoder"     % "4.2",
   "com.gu"                   %% "exact-target-lists"           % "0.1",
   "com.gu"                   %% "content-api-client-aws"       % "0.5",
-  "com.gu"                   %% "content-api-client"           % "12.14"
+  "com.gu"                   %% "content-api-client"           % "14.2"
 )
 
 resolvers ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= Seq(
   "net.logstash.logback"     %  "logstash-logback-encoder"     % "4.2",
   "com.gu"                   %% "exact-target-lists"           % "0.1",
   "com.gu"                   %% "content-api-client-aws"       % "0.5",
-  "com.gu"                   %% "content-api-client"           % "14.2"
+  "com.gu"                   %% "content-api-client"           % "14.1"
 )
 
 resolvers ++= Seq(


### PR DESCRIPTION
I've done a tag search and verified that updating an atom made it through to CAPI in code. Is there any other scenario I should test?