### PR TITLE
Add a temporary route for reindexing explainers

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,8 +1,10 @@
 import com.gu.atom.play.ReindexController
 import config.LogConfig
 import config.Config.{config, permissions, dynamoDB, capiDynamoDB, capiLambdaClient}
+import controllers.ExplainerReindexController
 import db.AtomDataStores._
 import db.AtomWorkshopDB
+import db.ExplainerDB
 import db.NotificationsDB
 import db.ReindexDataStores._
 import play.api.ApplicationLoader.Context
@@ -16,7 +18,7 @@ class AppComponents(context: Context)
 
   val logger = new LogConfig
 
-  lazy val router = new Routes(httpErrorHandler, appController, healthcheckController, loginController, assets, supportController, reindex, atomActionsController)
+  lazy val router = new Routes(httpErrorHandler, appController, healthcheckController, loginController, assets, supportController, reindex, explainerReindex, atomActionsController)
   lazy val assets = new controllers.Assets(httpErrorHandler)
   lazy val appController = new controllers.App(wsClient, atomWorkshopDB, permissions)
   lazy val loginController = new controllers.Login(wsClient)
@@ -26,7 +28,19 @@ class AppComponents(context: Context)
 
   lazy val reindex = new ReindexController(previewDataStore, publishedDataStore, reindexPreview, reindexPublished, Configuration(config), actorSystem)
 
+  lazy val explainerReindex = new ExplainerReindexController(
+    wsClient,
+    explainerDB,
+    explainerPreviewDataStore,
+    explainerPublishedDataStore,
+    reindexPreview,
+    reindexPublished,
+    Configuration(config)
+  )(actorSystem.dispatcher)
+
   lazy val atomWorkshopDB = new AtomWorkshopDB()
+
+  lazy val explainerDB = new ExplainerDB()
 
   lazy val notificationLists = new NotificationLists(capiLambdaClient)
 

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -61,6 +61,8 @@ object Config extends AwsInstanceTags {
 
   val previewDynamoTableName = config.getString("aws.dynamo.preview.tableName")
   val publishedDynamoTableName = config.getString("aws.dynamo.live.tableName")
+  val explainerPreviewDynamoTableName = config.getString("aws.dynamo.explainers.preview.tableName")
+  val explainerPublishedDynamoTableName = config.getString("aws.dynamo.explainers.live.tableName")
   val notificationsDynamoTableName = config.getString("aws.dynamo.notifications.tableName")
 
   val gridUrl = config.getString("grid.url")

--- a/app/controllers/ExplainerReindexController.scala
+++ b/app/controllers/ExplainerReindexController.scala
@@ -10,6 +10,7 @@ import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 import play.api.libs.json.Json
+import play.api.Logger
 
 class ExplainerReindexController(
   val wsClient: WSClient,
@@ -56,6 +57,8 @@ class ExplainerReindexController(
     Ok(Json.parse(s"""{ "status": "completed", "documentsIndexed": $result, "documentsExpected": $result }"""))
 
   private val displayError: PartialFunction[Throwable, Result] = {
-    case x: Throwable => InternalServerError(Json.parse(s"""{ "status": "failed", "documentsIndexed": 0, "documentsExpected": 0 }"""))
+    case x: Throwable => 
+      Logger.error("Something went wrong", x)
+      InternalServerError(Json.parse(s"""{ "status": "failed", "documentsIndexed": 0, "documentsExpected": 0 }"""))
   }
 }

--- a/app/controllers/ExplainerReindexController.scala
+++ b/app/controllers/ExplainerReindexController.scala
@@ -5,7 +5,7 @@ import com.gu.atom.publish.{AtomReindexer, PreviewAtomReindexer, PublishedAtomRe
 import db.ExplainerDBAPI
 import play.api.Configuration
 import play.api.libs.ws.WSClient
-import play.api.mvc.{ Action, AnyContent, Controller, Result }
+import play.api.mvc.{ Action, ActionBuilder, AnyContent, Controller, Result, Request }
 import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -20,7 +20,19 @@ class ExplainerReindexController(
   config: Configuration
 )(implicit ec: ExecutionContext) extends Controller with PanDomainAuthActions {
 
-  def reindex(stack: String): Action[AnyContent] = AuthAction.async { req => 
+  // Copy-pasted from the atom-maker library
+  object ApiKeyAction extends ActionBuilder[Request] {
+    lazy val apiKey = config.getString("reindexApiKey").get
+
+    def invokeBlock[A](request: Request[A], block: (Request[A] => Future[Result])) = {
+      if(request.getQueryString("api").contains(apiKey))
+        block(request)
+      else
+        Future.successful(Unauthorized(""))
+    }
+  }
+
+  def reindex(stack: String): Action[AnyContent] = ApiKeyAction.async { req => 
     stack match {
       case "preview" => run(previewDataStore, previewReindexer) map displayResult recover displayError
       case "published" => run(publishedDataStore, publishedReindexer) map displayResult recover displayError

--- a/app/controllers/ExplainerReindexController.scala
+++ b/app/controllers/ExplainerReindexController.scala
@@ -1,0 +1,47 @@
+package controllers
+
+import com.gu.atom.data.DynamoDataStore
+import com.gu.atom.publish.{AtomReindexer, PreviewAtomReindexer, PublishedAtomReindexer}
+import db.ExplainerDBAPI
+import play.api.Configuration
+import play.api.libs.ws.WSClient
+import play.api.mvc.{ Action, AnyContent, Controller, Result }
+import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+class ExplainerReindexController(
+  val wsClient: WSClient,
+  explainerDB: ExplainerDBAPI,
+  previewDataStore: DynamoDataStore,
+  publishedDataStore: DynamoDataStore,
+  previewReindexer: PreviewAtomReindexer,
+  publishedReindexer: PublishedAtomReindexer,
+  config: Configuration
+)(implicit ec: ExecutionContext) extends Controller with PanDomainAuthActions {
+
+  def reindex(stack: String): Action[AnyContent] = AuthAction.async { req => 
+    stack match {
+      case "preview" => run(previewDataStore, previewReindexer) map displayResult recover displayError
+      case "published" => run(publishedDataStore, publishedReindexer) map displayResult recover displayError
+      case x => Future.successful(BadRequest(s"$x is not a valid stack identifier"))
+    }
+  }
+
+  private def run(datastore: DynamoDataStore, reindexer: AtomReindexer): Future[Int] = {
+    explainerDB.listAtoms(datastore).fold(
+      apiError => Future.failed(new RuntimeException(apiError.msg)),
+      { atoms =>
+        val timestamp = System.nanoTime
+        val events = atoms.map(ContentAtomEvent(_, EventType.Update, timestamp))
+        reindexer.startReindexJob(events.iterator, events.size).execute
+      }
+    )
+  }
+
+  private def displayResult(result: Int): Result = Ok(s"Successfully reindexed $result explainers")
+
+  private val displayError: PartialFunction[Throwable, Result] = {
+    case x: Throwable => InternalServerError(s"Something went wrong: ${x.getMessage()}")
+  }
+}

--- a/app/controllers/ExplainerReindexController.scala
+++ b/app/controllers/ExplainerReindexController.scala
@@ -9,6 +9,7 @@ import play.api.mvc.{ Action, ActionBuilder, AnyContent, Controller, Result, Req
 import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
+import play.api.libs.json.Json
 
 class ExplainerReindexController(
   val wsClient: WSClient,
@@ -51,9 +52,10 @@ class ExplainerReindexController(
     )
   }
 
-  private def displayResult(result: Int): Result = Ok(s"Successfully reindexed $result explainers")
+  private def displayResult(result: Int): Result =
+    Ok(Json.parse(s"""{ "status": "completed", "documentsIndexed": $result, "documentsExpected": $result }"""))
 
   private val displayError: PartialFunction[Throwable, Result] = {
-    case x: Throwable => InternalServerError(s"Something went wrong: ${x.getMessage()}")
+    case x: Throwable => InternalServerError(Json.parse(s"""{ "status": "failed", "documentsIndexed": 0, "documentsExpected": 0 }"""))
   }
 }

--- a/app/controllers/ExplainerReindexController.scala
+++ b/app/controllers/ExplainerReindexController.scala
@@ -57,7 +57,7 @@ class ExplainerReindexController(
     explainerDB.listAtoms(datastore).fold(
       apiError => Future.failed(new RuntimeException(apiError.msg)),
       { atoms =>
-        val timestamp = System.nanoTime
+        val timestamp = System.currentTimeMillis
         val events = atoms.map(ContentAtomEvent(_, EventType.Update, timestamp))
         reindexer.startReindexJob(events.iterator, events.size).execute
       }
@@ -73,7 +73,7 @@ class ExplainerReindexController(
 
   private val displayError: PartialFunction[Throwable, Result] = {
     case x: Throwable => 
-      Logger.error("Something went wrong", x)
+      Logger.error("Failed to reindex explainer atoms", x)
       InternalServerError(Json.parse(s"""{ "status": "failed", "documentsIndexed": 0, "documentsExpected": 0 }"""))
   }
 }

--- a/app/db/AtomDataStores.scala
+++ b/app/db/AtomDataStores.scala
@@ -13,6 +13,9 @@ object AtomDataStores {
 
   val previewDataStore = new PreviewDynamoDataStore(dynamoDB, previewDynamoTableName)
   val publishedDataStore = new PublishedDynamoDataStore(dynamoDB, publishedDynamoTableName)
+  
+  val explainerPreviewDataStore = new PreviewDynamoDataStore(dynamoDB, explainerPreviewDynamoTableName)
+  val explainerPublishedDataStore = new PublishedDynamoDataStore(dynamoDB, explainerPublishedDynamoTableName)
 }
 
 object ReindexDataStores {

--- a/app/db/ExplainerDB.scala
+++ b/app/db/ExplainerDB.scala
@@ -1,0 +1,27 @@
+package db
+
+import com.gu.atom.data.DynamoDataStore
+import com.gu.contentatom.thrift.Atom
+import models.{AtomAPIError, ExplainerDynamoDatastoreError}
+import play.api.Logger
+import util.AtomLogic._
+
+trait ExplainerDBAPI {
+  def listAtoms(datastore: DynamoDataStore): Either[AtomAPIError, List[Atom]]
+}
+
+class ExplainerDB() extends ExplainerDBAPI {
+
+  def listAtoms(datastore: DynamoDataStore): Either[AtomAPIError, List[Atom]] = {
+    Logger.info(s"Attempting to read all explainers from ${datastore.getClass.getName}")
+    try {
+      val result = datastore.listAtoms
+      Logger.info(s"Successfully read alls explainers from ${datastore.getClass.getName}")
+      result.fold({
+        case x: Throwable => Left(ExplainerDynamoDatastoreError(x.getMessage))
+      }, Right(_))
+    } catch {
+      case e: Exception => processException(e)
+    }
+  }
+}

--- a/app/models/Errors.scala
+++ b/app/models/Errors.scala
@@ -11,6 +11,7 @@ case object DeleteAtomFromPreviewError extends AtomAPIError("Could not delete at
 case class CreateAtomDynamoError(atomJson: String, message: String) extends AtomAPIError(s"Error thrown by Dynamo when attempting to create atom. JSON of atom: $atomJson, error message: $message")
 case class AmazonDynamoError(message: String) extends AtomAPIError(s"Error thrown by Dynamo: $message")
 case class AtomWorkshopDynamoDatastoreError(message: String) extends AtomAPIError(message)
+case class ExplainerDynamoDatastoreError(message: String) extends AtomAPIError(message)
 case class AtomJsonParsingError(message: String) extends AtomAPIError(s"Failed to parse Json string with error: $message")
 case class AtomThriftDeserialisingError(message: String) extends AtomAPIError(s"Failed to deserialise JSON into thrift with error: $message")
 case class NotificationListsError(message: String) extends AtomAPIError(s"Notification lists error for atom: $message")

--- a/conf/routes
+++ b/conf/routes
@@ -44,6 +44,7 @@ GET     /reindex-publish                         com.gu.atom.play.ReindexControl
 
 #Temporary explainers reindex
 POST    /explainers/reindex                      controllers.ExplainerReindexController.reindex(stack: String)
+GET     /explainers/reindex                      controllers.ExplainerReindexController.status(stack: String)
 
 # Custom atom actions
 POST    /api/live/:atomType/:id/custom/notifications controllers.AtomActions.createNotificationList(atomType: String, id: String)

--- a/conf/routes
+++ b/conf/routes
@@ -43,7 +43,7 @@ GET     /reindex-preview                         com.gu.atom.play.ReindexControl
 GET     /reindex-publish                         com.gu.atom.play.ReindexController.publishedReindexJobStatus()
 
 #Temporary explainers reindex
-GET     /explainers/reindex                      controllers.ExplainerReindexController.reindex(stack: String)
+POST    /explainers/reindex                      controllers.ExplainerReindexController.reindex(stack: String)
 
 # Custom atom actions
 POST    /api/live/:atomType/:id/custom/notifications controllers.AtomActions.createNotificationList(atomType: String, id: String)

--- a/conf/routes
+++ b/conf/routes
@@ -42,6 +42,9 @@ POST    /reindex-publish                         com.gu.atom.play.ReindexControl
 GET     /reindex-preview                         com.gu.atom.play.ReindexController.previewReindexJobStatus()
 GET     /reindex-publish                         com.gu.atom.play.ReindexController.publishedReindexJobStatus()
 
+#Temporary explainers reindex
+GET     /explainers/reindex                      controllers.ExplainerReindexController.reindex(stack: String)
+
 # Custom atom actions
 POST    /api/live/:atomType/:id/custom/notifications controllers.AtomActions.createNotificationList(atomType: String, id: String)
 DELETE  /api/live/:atomType/:id/custom/notifications controllers.AtomActions.deleteNotificationList(atomType: String, id: String)


### PR DESCRIPTION
As part of the move to the new atoms index, all existing atoms must be backfilled. This is proving difficult for explainers in particular, as we decommissioned them a while ago: the authoring app, in particular, is gone. To avoid resurrecting it, it is much simpler to use atom workshop instead, which already has nice interfaces with DynamoDB and Kinesis.

There are not many explainer atoms (~300 on PROD), so I've kept the code to the bare minimum.

- [x] Tested on CODE
- [x] Update floodgate to use the new route on CODE
- [x] Update floodgate to use the new route on PROD