### PR TITLE
Add highlight error

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import {ManagedForm, ManagedField} from '../../../ManagedEditor';
+import { ManagedForm, ManagedField } from '../../../ManagedEditor';
 import FormFieldsScribeEditor from '../../../FormFields/FormFieldScribeEditor';
 
 const WordLimit = 250;
@@ -22,7 +22,7 @@ export class QAItem extends React.Component {
     this.props.onUpdateField(item);
   }
 
-  render () {
+  render() {
     const value = this.props.fieldValue || {
       title: "",
       body: ""
@@ -31,7 +31,11 @@ export class QAItem extends React.Component {
       <div className="form__field">
         <ManagedForm data={value} updateData={this.updateItem} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="qaEditor">
           <ManagedField fieldLocation="body" name="Answer" isRequired={true}>
-            <FormFieldsScribeEditor showWordCount={true} suggestedLength={WordLimit} showToolbar={true} tooLongMsg={`You've exceeded the ${WordLimit} word limit for this atom.`}/>
+            <FormFieldsScribeEditor
+              showWordCount={true}
+              suggestedLength={WordLimit}
+              showToolbar={true}
+              tooLongMsg={<div>Heads up. <strong>You've exceeded the {WordLimit} word limit for this field.</strong> You can still publish it, but bear in mind that atoms should be concise.</div>} />
           </ManagedField>
         </ManagedForm>
       </div>

--- a/public/js/components/FormFields/FormFieldScribeEditor.js
+++ b/public/js/components/FormFields/FormFieldScribeEditor.js
@@ -55,7 +55,7 @@ export default class FormFieldsScribeEditor extends React.Component {
       <div className={(this.props.formRowClass || "form__row") + " scribe"}>
         {this.props.fieldLabel ? <label htmlFor={this.props.fieldName} className="form__label">{this.props.fieldLabel}</label> : false}
         <ScribeEditor
-          ref={this.props.fieldName}
+          key={this.props.fieldName}
           fieldName={this.props.fieldName}
           value={this.props.fieldValue ? this.props.fieldValue : " "}
           onUpdate={this.props.onUpdateField}

--- a/public/js/components/FormFields/FormFieldScribeEditor.js
+++ b/public/js/components/FormFields/FormFieldScribeEditor.js
@@ -1,10 +1,10 @@
-import React, {PropTypes} from 'react';
+import React, { PropTypes } from 'react';
 import Scribe from 'scribe';
 import scribeKeyboardShortcutsPlugin from 'scribe-plugin-keyboard-shortcuts';
 import scribePluginToolbar from 'scribe-plugin-toolbar';
 import scribePluginLinkPromptCommand from 'scribe-plugin-link-prompt-command';
 import scribePluginSanitizer from 'scribe-plugin-sanitizer';
-import {errorPropType} from '../../constants/errorPropType';
+import { errorPropType } from '../../constants/errorPropType';
 import ShowErrors from '../Utilities/ShowErrors';
 import uuidv4 from 'uuid/v4';
 
@@ -20,7 +20,7 @@ export default class FormFieldsScribeEditor extends React.Component {
     showWordCount: PropTypes.bool,
     suggestedLength: PropTypes.number,
     showToolbar: PropTypes.bool,
-    tooLongMsg: PropTypes.string
+    tooLongMsg: PropTypes.node
   }
 
   constructor(props) {
@@ -37,27 +37,33 @@ export default class FormFieldsScribeEditor extends React.Component {
   isTooLong = (wordCount) => this.props.suggestedLength && wordCount > this.props.suggestedLength;
 
   renderWordCount = () => {
-    const wordCount = this.props.fieldValue? this.wordCount(this.props.fieldValue) : 0;
+    const wordCount = this.props.fieldValue ? this.wordCount(this.props.fieldValue) : 0;
 
     const tooLong = this.isTooLong(wordCount);
 
     return (
-        <div>
-          <span className="form__message__text">{wordCount} words</span>
-          {tooLong ? <span className="form__message__text--error"> ({this.tooLongMsg})</span>: false}
-        </div>
+      <div className="form__message" data-highlighted={tooLong}>
+        <span className="form__message__title">{wordCount} words</span>
+        {tooLong ? <div className="form__message__text"> {this.tooLongMsg}</div> : false}
+      </div>
     );
   }
 
 
-  render () {
+  render() {
     return (
-        <div className={(this.props.formRowClass || "form__row") + " scribe"}>
-          {this.props.fieldLabel ? <label htmlFor={this.props.fieldName} className="form__label">{this.props.fieldLabel}</label> : false}
-          <ScribeEditor fieldName={this.props.fieldName} value={this.props.fieldValue ? this.props.fieldValue: " " } onUpdate={this.props.onUpdateField} showToolbar={this.props.showToolbar}/>
-          {this.props.showWordCount ? this.renderWordCount() : false}
-          <ShowErrors errors={this.props.fieldErrors}/>
-        </div>
+      <div className={(this.props.formRowClass || "form__row") + " scribe"}>
+        {this.props.fieldLabel ? <label htmlFor={this.props.fieldName} className="form__label">{this.props.fieldLabel}</label> : false}
+        <ScribeEditor
+          ref={this.props.fieldName}
+          fieldName={this.props.fieldName}
+          value={this.props.fieldValue ? this.props.fieldValue : " "}
+          onUpdate={this.props.onUpdateField}
+          showToolbar={this.props.showToolbar}
+        />
+        {this.props.showWordCount ? this.renderWordCount() : false}
+        <ShowErrors errors={this.props.fieldErrors} />
+      </div>
     );
   }
 }
@@ -78,9 +84,9 @@ export class ScribeEditor extends React.Component {
   uuid = uuidv4();
 
   componentDidMount() {
-      this.setState({scribeElement: document.getElementById(this.props.fieldName+this.uuid)}, () => {
-        this.configureScribe();
-      });
+    this.setState({ scribeElement: document.getElementById(this.props.fieldName + this.uuid) }, () => {
+      this.configureScribe();
+    });
 
   }
 
@@ -120,7 +126,7 @@ export class ScribeEditor extends React.Component {
     this.scribe.on('content-changed', this.onContentChange);
 
     this.setState({
-        scribeElement: Object.assign(this.state.scribeElement, {innerHTML: this.props.value})
+      scribeElement: Object.assign(this.state.scribeElement, { innerHTML: this.props.value })
     });
   }
 
@@ -137,18 +143,18 @@ export class ScribeEditor extends React.Component {
 
   render() {
     return (
-        <div>
-          { this.props.showToolbar === false ? null :
-            <div id={`scribe__toolbar-${this.uuid}`} className="scribe__toolbar">
-              <button type="button" data-command-name="bold" className="scribe__toolbar__item">Bold</button>
-              <button type="button" data-command-name="italic" className="scribe__toolbar__item">Italic</button>
-              <button type="button" data-command-name="linkPrompt" className="scribe__toolbar__item">Link</button>
-              <button type="button" data-command-name="unlink" className="scribe__toolbar__item">Unlink</button>
-            </div>
-          }
+      <div>
+        {this.props.showToolbar === false ? null :
+          <div id={`scribe__toolbar-${this.uuid}`} className="scribe__toolbar">
+            <button type="button" data-command-name="bold" className="scribe__toolbar__item">Bold</button>
+            <button type="button" data-command-name="italic" className="scribe__toolbar__item">Italic</button>
+            <button type="button" data-command-name="linkPrompt" className="scribe__toolbar__item">Link</button>
+            <button type="button" data-command-name="unlink" className="scribe__toolbar__item">Unlink</button>
+          </div>
+        }
 
-          <div id={this.props.fieldName + this.uuid} className="scribe__editor"></div>
-        </div>
-  );
+        <div id={this.props.fieldName + this.uuid} className="scribe__editor"></div>
+      </div>
+    );
   }
 }

--- a/public/styles/components/_forms.scss
+++ b/public/styles/components/_forms.scss
@@ -211,7 +211,7 @@
 .form__message {
   margin-bottom: 10px;
 
-  &[data-highlighted=true] {
+  &[data-highlighted="true"] {
     overflow: hidden;
     background-color: lighten($cYellow, 40);
     padding: 5px 10px;

--- a/public/styles/components/_forms.scss
+++ b/public/styles/components/_forms.scss
@@ -210,6 +210,24 @@
 
 .form__message {
   margin-bottom: 10px;
+
+  &[data-highlighted=true] {
+    overflow: hidden;
+    background-color: lighten($cYellow, 40);
+    padding: 5px 10px;
+
+    .form__message__title {
+      margin: -5px 0 5px -10px;
+      padding: 5px;
+      background-color: lighten($cYellow, 30);
+      display: inline-block;
+    }
+  }
+}
+
+.form__message__title {
+  font-size: 13px;
+  font-weight: 700;
 }
 
 .form__message__text {


### PR DESCRIPTION
As an editorial user, I want to create/update atoms logically and easily, so that my time is utilised as effectively as possible.
The word count messages on snippets are currently misleading. The warnings look like error messages that prevent users from continuing their work.

[More on trello](https://trello.com/c/bf2DoMO8/642-change-word-count-warning-copy-to-xxxxx)

## Screenies
<img width="467" alt="Screenshot 2019-05-02 at 13 01 45" src="https://user-images.githubusercontent.com/11539094/57074156-f6280900-6cda-11e9-8486-7e42d25e192c.png">
