### PR TITLE
Use `Tag#internalName` for autocomplete in line with Composer

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -61,8 +61,8 @@ object Config extends AwsInstanceTags {
 
   val previewDynamoTableName = config.getString("aws.dynamo.preview.tableName")
   val publishedDynamoTableName = config.getString("aws.dynamo.live.tableName")
-  val explainerPreviewDynamoTableName = getOptionalProperty("aws.dynamo.explainers.preview.tableName", config.getString).getOrElse("")
-  val explainerPublishedDynamoTableName = getOptionalProperty("aws.dynamo.explainers.live.tableName", config.getString).getOrElse("")
+  val explainerPreviewDynamoTableName = getOptionalProperty("aws.dynamo.explainers.preview.tableName", config.getString).getOrElse("explain-maker-preview-DEV")
+  val explainerPublishedDynamoTableName = getOptionalProperty("aws.dynamo.explainers.live.tableName", config.getString).getOrElse("explain-maker-live-DEV")
   val notificationsDynamoTableName = config.getString("aws.dynamo.notifications.tableName")
 
   val gridUrl = config.getString("grid.url")

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -61,8 +61,8 @@ object Config extends AwsInstanceTags {
 
   val previewDynamoTableName = config.getString("aws.dynamo.preview.tableName")
   val publishedDynamoTableName = config.getString("aws.dynamo.live.tableName")
-  val explainerPreviewDynamoTableName = config.getString("aws.dynamo.explainers.preview.tableName")
-  val explainerPublishedDynamoTableName = config.getString("aws.dynamo.explainers.live.tableName")
+  val explainerPreviewDynamoTableName = getOptionalProperty("aws.dynamo.explainers.preview.tableName", config.getString).getOrElse("")
+  val explainerPublishedDynamoTableName = getOptionalProperty("aws.dynamo.explainers.live.tableName", config.getString).getOrElse("")
   val notificationsDynamoTableName = config.getString("aws.dynamo.notifications.tableName")
 
   val gridUrl = config.getString("grid.url")

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -83,6 +83,8 @@ object Config extends AwsInstanceTags {
   val capiPreviewIAMUrl = config.getString("capi.previewIAMUrl")
   val capiLiveUrl = config.getString("capi.liveUrl")
 
+  val capiApiKey = getOptionalProperty("capi.apiKey", config.getString).getOrElse("atom-workshop-DEV")
+
   val capiCredentialsProvider = new ProfileCredentialsProvider("capi")
   val capiPreviewRole = config.getString("capi.previewRole")
   val capiPreviewCredentials: AWSCredentialsProvider = {

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -21,7 +21,7 @@ class Support(val wsClient: WSClient) extends Controller with PanDomainAuthActio
   def previewCapiProxy(path: String) = APIAuthAction.async { request =>
     val capiUrl = Config.capiPreviewIAMUrl
 
-    val url = s"$capiUrl/$path?${request.rawQueryString}"
+    val url = s"$capiUrl/$path?user-tier=internal&${request.rawQueryString}"
 
     val req = wsClient
       .url(url)

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -5,9 +5,10 @@ import java.net.URI
 import com.gu.contentapi.client.IAMSigner
 import config.Config
 import play.api.libs.ws.WSClient
-import play.api.mvc.Controller
+import play.api.mvc.{ Controller, Result }
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.Logger
+import scala.concurrent.Future
 
 class Support(val wsClient: WSClient) extends Controller with PanDomainAuthActions {
 
@@ -18,14 +19,19 @@ class Support(val wsClient: WSClient) extends Controller with PanDomainAuthActio
 
   private def getHeaders(url: String): Seq[(String,String)] = signer.addIAMHeaders(headers = Map.empty, uri = URI.create(url)).toSeq
 
+  def capiProxy(path: String) = APIAuthAction.async { request =>
+    query(s"${Config.capiLiveUrl}/$path?api-key=${Config.capiApiKey}&${request.rawQueryString}", Seq.empty)
+  }
+
   def previewCapiProxy(path: String) = APIAuthAction.async { request =>
-    val capiUrl = Config.capiPreviewIAMUrl
+    val url = s"${Config.capiPreviewIAMUrl}/$path?${request.rawQueryString}"
+    query(url, getHeaders(url))
+  }
 
-    val url = s"$capiUrl/$path?user-tier=internal&${request.rawQueryString}"
-
+  def query(url: String, headers: Seq[(String, String)]): Future[Result] = {
     val req = wsClient
       .url(url)
-      .withHeaders(getHeaders(url): _*)
+      .withHeaders(headers: _*)
       .get()
 
     req.map(response => response.status match {

--- a/conf/routes
+++ b/conf/routes
@@ -34,6 +34,7 @@ GET     /reauth                                  controllers.Login.reauth
 GET     /assets/*file                            controllers.Assets.versioned(path="/public", file: Asset)
 
 #Support
+GET /support/capi/*path                          controllers.Support.capiProxy(path: String)
 GET /support/previewCapi/*path                   controllers.Support.previewCapiProxy(path: String)
 
 #Reindex

--- a/public/js/components/FormFields/FormFieldTagPicker.js
+++ b/public/js/components/FormFields/FormFieldTagPicker.js
@@ -39,20 +39,27 @@ export default class FormFieldTagPicker extends React.Component {
 
     const searchText = e.target.value;
 
-    this.setState({
-      searchText: searchText
-    });
-
-    searchTags(searchText, this.props.tagType).then((results) => {
+    if (searchText.length > 0) {
       this.setState({
-        suggestions: results
+        searchText: searchText
       });
-    })
-    .catch(() => {
+    
+      searchTags(searchText, this.props.tagType).then((results) => {
+        this.setState({
+          suggestions: results
+        });
+      })
+      .catch(() => {
+        this.setState({
+          suggestions: null
+        });
+      });
+    } else {
       this.setState({
-        suggestions: null
+        searchText: "",
+        suggestions: []
       });
-    });
+    }
 
   }
 

--- a/public/js/services/capi.js
+++ b/public/js/services/capi.js
@@ -4,7 +4,7 @@ import { uriEncodeParams, sanitiseQuery } from '../util/uriEncodeParams';
 
 export const searchTags = (searchText, type = null) => {
   return pandaFetch(
-    `/support/previewCapi/tags?q=${searchText}${type ? `&type=${type}` : ''}`,
+    `/support/previewCapi/tags?internal-name=${searchText}${type ? `&type=${type}` : ''}`,
     {
       method: 'get',
       credentials: 'same-origin'

--- a/public/js/services/capi.js
+++ b/public/js/services/capi.js
@@ -4,7 +4,7 @@ import { uriEncodeParams, sanitiseQuery } from '../util/uriEncodeParams';
 
 export const searchTags = (searchText, type = null) => {
   return pandaFetch(
-    `/support/previewCapi/tags?internal-name=${searchText}${type ? `&type=${type}` : ''}`,
+    `/support/capi/tags?internal-name=${searchText}${type ? `&type=${type}` : ''}`,
     {
       method: 'get',
       credentials: 'same-origin'


### PR DESCRIPTION
This is a long-standing request by CP that AW uses the tags' internal name for type-ahead recommendations. In this PR, I made two changes:

- uses the new `internal-name` filter for querying tags. I'm also forcing the request on the internal tier, though I'm not sure this is necessary for preview but I couldn't find anything related in Concierge
- prevents a request to be done when the search text is empty

<img width="303" alt="Screenshot 2019-05-10 at 10 56 22" src="https://user-images.githubusercontent.com/629976/57518993-4540f000-7312-11e9-81bb-4daac9a0d882.png">

Additionally I fixed a local dev bug where the explainer reindex controller couldn't start because of some missing configuration.