### PR TITLE
Change word limit in guide atoms

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "tabWidth": 2,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "singleQuote": true
 }

--- a/public/js/components/AtomEdit/CustomEditors/GuideEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/GuideEditor.js
@@ -1,36 +1,42 @@
 import React, { PropTypes } from 'react';
 import FormFieldImageSelect from '../../FormFields/FormFieldImageSelect';
 import FormFieldArrayWrapper from '../../FormFields/FormFieldArrayWrapper';
-import {GuideItem} from './GuideFields/GuideItem';
-import {ManagedField, ManagedForm} from '../../ManagedEditor';
-import {atomPropType} from '../../../constants/atomPropType';
-import {checkItemsUnderWordCount} from '../../../util/validators';
+import { GuideItem } from './GuideFields/GuideItem';
+import { ManagedField, ManagedForm } from '../../ManagedEditor';
+import { atomPropType } from '../../../constants/atomPropType';
 
 export class GuideEditor extends React.Component {
+	static propTypes = {
+		atom: atomPropType.isRequired,
+		onUpdate: PropTypes.func.isRequired,
+		onFormErrorsUpdate: PropTypes.func,
+		config: PropTypes.shape({
+			gridUrl: PropTypes.string.isRequired,
+		}).isRequired,
+	};
 
-  static propTypes = {
-    atom: atomPropType.isRequired,
-    onUpdate: PropTypes.func.isRequired,
-    onFormErrorsUpdate: PropTypes.func,
-    config: PropTypes.shape({
-      gridUrl: PropTypes.string.isRequired
-    }).isRequired
-  }
-
-  render () {
-    return (
-      <div className="form">
-        <ManagedForm data={this.props.atom} updateData={this.props.onUpdate} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="guideEditor">
-          <ManagedField fieldLocation="data.guide.guideImage" name="Guide Image">
-            <FormFieldImageSelect gridUrl={this.props.config.gridUrl}/>
-          </ManagedField>
-          <ManagedField fieldLocation="data.guide.items" name="Items" customValidation={[checkItemsUnderWordCount]}>
-            <FormFieldArrayWrapper>
-              <GuideItem onFormErrorsUpdate={this.props.onFormErrorsUpdate} />
-            </FormFieldArrayWrapper>
-          </ManagedField>
-        </ManagedForm>
-      </div>
-    );
-  }
+	render() {
+		return (
+			<div className="form">
+				<ManagedForm
+					data={this.props.atom}
+					updateData={this.props.onUpdate}
+					onFormErrorsUpdate={this.props.onFormErrorsUpdate}
+					formName="guideEditor"
+				>
+					<ManagedField
+						fieldLocation="data.guide.guideImage"
+						name="Guide Image"
+					>
+						<FormFieldImageSelect gridUrl={this.props.config.gridUrl} />
+					</ManagedField>
+					<ManagedField fieldLocation="data.guide.items" name="Items">
+						<FormFieldArrayWrapper>
+							<GuideItem onFormErrorsUpdate={this.props.onFormErrorsUpdate} />
+						</FormFieldArrayWrapper>
+					</ManagedField>
+				</ManagedForm>
+			</div>
+		);
+	}
 }

--- a/public/js/components/AtomEdit/CustomEditors/GuideEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/GuideEditor.js
@@ -1,42 +1,42 @@
-import React, { PropTypes } from 'react';
-import FormFieldImageSelect from '../../FormFields/FormFieldImageSelect';
-import FormFieldArrayWrapper from '../../FormFields/FormFieldArrayWrapper';
-import { GuideItem } from './GuideFields/GuideItem';
-import { ManagedField, ManagedForm } from '../../ManagedEditor';
-import { atomPropType } from '../../../constants/atomPropType';
+import React, { PropTypes } from "react";
+import FormFieldImageSelect from "../../FormFields/FormFieldImageSelect";
+import FormFieldArrayWrapper from "../../FormFields/FormFieldArrayWrapper";
+import { GuideItem } from "./GuideFields/GuideItem";
+import { ManagedField, ManagedForm } from "../../ManagedEditor";
+import { atomPropType } from "../../../constants/atomPropType";
 
 export class GuideEditor extends React.Component {
-	static propTypes = {
-		atom: atomPropType.isRequired,
-		onUpdate: PropTypes.func.isRequired,
-		onFormErrorsUpdate: PropTypes.func,
-		config: PropTypes.shape({
-			gridUrl: PropTypes.string.isRequired,
-		}).isRequired,
-	};
+  static propTypes = {
+    atom: atomPropType.isRequired,
+    onUpdate: PropTypes.func.isRequired,
+    onFormErrorsUpdate: PropTypes.func,
+    config: PropTypes.shape({
+      gridUrl: PropTypes.string.isRequired,
+    }).isRequired,
+  };
 
-	render() {
-		return (
-			<div className="form">
-				<ManagedForm
-					data={this.props.atom}
-					updateData={this.props.onUpdate}
-					onFormErrorsUpdate={this.props.onFormErrorsUpdate}
-					formName="guideEditor"
-				>
-					<ManagedField
-						fieldLocation="data.guide.guideImage"
-						name="Guide Image"
-					>
-						<FormFieldImageSelect gridUrl={this.props.config.gridUrl} />
-					</ManagedField>
-					<ManagedField fieldLocation="data.guide.items" name="Items">
-						<FormFieldArrayWrapper>
-							<GuideItem onFormErrorsUpdate={this.props.onFormErrorsUpdate} />
-						</FormFieldArrayWrapper>
-					</ManagedField>
-				</ManagedForm>
-			</div>
-		);
-	}
+  render() {
+    return (
+      <div className="form">
+        <ManagedForm
+          data={this.props.atom}
+          updateData={this.props.onUpdate}
+          onFormErrorsUpdate={this.props.onFormErrorsUpdate}
+          formName="guideEditor"
+        >
+          <ManagedField
+            fieldLocation="data.guide.guideImage"
+            name="Guide Image"
+          >
+            <FormFieldImageSelect gridUrl={this.props.config.gridUrl} />
+          </ManagedField>
+          <ManagedField fieldLocation="data.guide.items" name="Items">
+            <FormFieldArrayWrapper>
+              <GuideItem onFormErrorsUpdate={this.props.onFormErrorsUpdate} />
+            </FormFieldArrayWrapper>
+          </ManagedField>
+        </ManagedForm>
+      </div>
+    );
+  }
 }

--- a/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
@@ -1,45 +1,56 @@
 import React, { PropTypes } from 'react';
-import {ManagedForm, ManagedField} from '../../../ManagedEditor';
+import { ManagedForm, ManagedField } from '../../../ManagedEditor';
 import FormFieldTextInput from '../../../FormFields/FormFieldTextInput';
 import FormFieldsScribeEditor from '../../../FormFields/FormFieldScribeEditor';
 import ShowErrors from '../../../Utilities/ShowErrors';
 import { errorPropType } from '../../../../constants/errorPropType';
+import { wordLimits, tooLongMsg } from '../../../../util/wordLimits';
 
 export class GuideItem extends React.Component {
-  static propTypes = {
-    fieldLabel: PropTypes.string,
-    fieldErrors: PropTypes.arrayOf(errorPropType),
-    fieldName: PropTypes.string,
-    fieldValue: PropTypes.shape({
-      title: PropTypes.string,
-      body: PropTypes.string
-    }),
-    fieldPlaceholder: PropTypes.string,
-    onUpdateField: PropTypes.func,
-    onFormErrorsUpdate: PropTypes.func
-  };
+	static propTypes = {
+		fieldLabel: PropTypes.string,
+		fieldErrors: PropTypes.arrayOf(errorPropType),
+		fieldName: PropTypes.string,
+		fieldValue: PropTypes.shape({
+			title: PropTypes.string,
+			body: PropTypes.string,
+		}),
+		fieldPlaceholder: PropTypes.string,
+		onUpdateField: PropTypes.func,
+		onFormErrorsUpdate: PropTypes.func,
+	};
 
-  updateItem = (item) => {
-    this.props.onUpdateField(item);
-  }
+	updateItem = item => {
+		this.props.onUpdateField(item);
+	};
 
-  render () {
-    const value = this.props.fieldValue || {
-      title: null,
-      body: "-"
-    };
-    return (
-      <div className="form__field form__field--nested">
-        <ManagedForm data={value} updateData={this.updateItem} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="guideEditor">
-          <ManagedField fieldLocation="title" name="Title">
-            <FormFieldTextInput/>
-          </ManagedField>
-          <ManagedField fieldLocation="body" name="Body" isRequired={true}>
-            <FormFieldsScribeEditor showWordCount={true} showToolbar={true} tooLongMsg={"Remember that snippets should be concise"}/>
-          </ManagedField>
-        </ManagedForm>
-        <ShowErrors errors={this.props.fieldErrors}/>
-      </div>
-    );
-  }
+	render() {
+		const value = this.props.fieldValue || {
+			title: null,
+			body: '-',
+		};
+		return (
+			<div className="form__field form__field--nested">
+				<ManagedForm
+					data={value}
+					updateData={this.updateItem}
+					onFormErrorsUpdate={this.props.onFormErrorsUpdate}
+					formName="guideEditor"
+				>
+					<ManagedField fieldLocation="title" name="Title">
+						<FormFieldTextInput />
+					</ManagedField>
+					<ManagedField fieldLocation="body" name="Body" isRequired={true}>
+						<FormFieldsScribeEditor
+							showWordCount={true}
+							showToolbar={true}
+							suggestedLength={wordLimits.default}
+							tooLongMsg={tooLongMsg}
+						/>
+					</ManagedField>
+				</ManagedForm>
+				<ShowErrors errors={this.props.fieldErrors} />
+			</div>
+		);
+	}
 }

--- a/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
@@ -45,7 +45,7 @@ export class GuideItem extends React.Component {
 							showWordCount={true}
 							showToolbar={true}
 							suggestedLength={wordLimits.default}
-							tooLongMsg={tooLongMsg}
+							tooLongMsg={tooLongMsg(wordLimits.default)}
 						/>
 					</ManagedField>
 				</ManagedForm>

--- a/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/GuideFields/GuideItem.js
@@ -1,56 +1,56 @@
-import React, { PropTypes } from 'react';
-import { ManagedForm, ManagedField } from '../../../ManagedEditor';
-import FormFieldTextInput from '../../../FormFields/FormFieldTextInput';
-import FormFieldsScribeEditor from '../../../FormFields/FormFieldScribeEditor';
-import ShowErrors from '../../../Utilities/ShowErrors';
-import { errorPropType } from '../../../../constants/errorPropType';
-import { wordLimits, tooLongMsg } from '../../../../util/wordLimits';
+import React, { PropTypes } from "react";
+import { ManagedForm, ManagedField } from "../../../ManagedEditor";
+import FormFieldTextInput from "../../../FormFields/FormFieldTextInput";
+import FormFieldsScribeEditor from "../../../FormFields/FormFieldScribeEditor";
+import ShowErrors from "../../../Utilities/ShowErrors";
+import { errorPropType } from "../../../../constants/errorPropType";
+import { wordLimits, tooLongMsg } from "../../../../util/wordLimits";
 
 export class GuideItem extends React.Component {
-	static propTypes = {
-		fieldLabel: PropTypes.string,
-		fieldErrors: PropTypes.arrayOf(errorPropType),
-		fieldName: PropTypes.string,
-		fieldValue: PropTypes.shape({
-			title: PropTypes.string,
-			body: PropTypes.string,
-		}),
-		fieldPlaceholder: PropTypes.string,
-		onUpdateField: PropTypes.func,
-		onFormErrorsUpdate: PropTypes.func,
-	};
+  static propTypes = {
+    fieldLabel: PropTypes.string,
+    fieldErrors: PropTypes.arrayOf(errorPropType),
+    fieldName: PropTypes.string,
+    fieldValue: PropTypes.shape({
+      title: PropTypes.string,
+      body: PropTypes.string,
+    }),
+    fieldPlaceholder: PropTypes.string,
+    onUpdateField: PropTypes.func,
+    onFormErrorsUpdate: PropTypes.func,
+  };
 
-	updateItem = item => {
-		this.props.onUpdateField(item);
-	};
+  updateItem = item => {
+    this.props.onUpdateField(item);
+  };
 
-	render() {
-		const value = this.props.fieldValue || {
-			title: null,
-			body: '-',
-		};
-		return (
-			<div className="form__field form__field--nested">
-				<ManagedForm
-					data={value}
-					updateData={this.updateItem}
-					onFormErrorsUpdate={this.props.onFormErrorsUpdate}
-					formName="guideEditor"
-				>
-					<ManagedField fieldLocation="title" name="Title">
-						<FormFieldTextInput />
-					</ManagedField>
-					<ManagedField fieldLocation="body" name="Body" isRequired={true}>
-						<FormFieldsScribeEditor
-							showWordCount={true}
-							showToolbar={true}
-							suggestedLength={wordLimits.default}
-							tooLongMsg={tooLongMsg(wordLimits.default)}
-						/>
-					</ManagedField>
-				</ManagedForm>
-				<ShowErrors errors={this.props.fieldErrors} />
-			</div>
-		);
-	}
+  render() {
+    const value = this.props.fieldValue || {
+      title: null,
+      body: "-",
+    };
+    return (
+      <div className="form__field form__field--nested">
+        <ManagedForm
+          data={value}
+          updateData={this.updateItem}
+          onFormErrorsUpdate={this.props.onFormErrorsUpdate}
+          formName="guideEditor"
+        >
+          <ManagedField fieldLocation="title" name="Title">
+            <FormFieldTextInput />
+          </ManagedField>
+          <ManagedField fieldLocation="body" name="Body" isRequired={true}>
+            <FormFieldsScribeEditor
+              showWordCount={true}
+              showToolbar={true}
+              suggestedLength={wordLimits.default}
+              tooLongMsg={tooLongMsg(wordLimits.default)}
+            />
+          </ManagedField>
+        </ManagedForm>
+        <ShowErrors errors={this.props.fieldErrors} />
+      </div>
+    );
+  }
 }

--- a/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
@@ -1,44 +1,49 @@
 import React, { PropTypes } from 'react';
 import { ManagedForm, ManagedField } from '../../../ManagedEditor';
 import FormFieldsScribeEditor from '../../../FormFields/FormFieldScribeEditor';
-
-const WordLimit = 250;
+import { wordLimits, tooLongMsg } from '../../../../util/wordLimits';
 
 export class QAItem extends React.Component {
-  static propTypes = {
-    fieldLabel: PropTypes.string,
-    fieldName: PropTypes.string,
-    fieldValue: PropTypes.shape({
-      title: PropTypes.string,
-      date: PropTypes.date,
-      body: PropTypes.string
-    }),
-    fieldPlaceholder: PropTypes.string,
-    onUpdateField: PropTypes.func,
-    onFormErrorsUpdate: PropTypes.func
-  };
+	static propTypes = {
+		fieldLabel: PropTypes.string,
+		fieldName: PropTypes.string,
+		fieldValue: PropTypes.shape({
+			title: PropTypes.string,
+			date: PropTypes.date,
+			body: PropTypes.string,
+		}),
+		fieldPlaceholder: PropTypes.string,
+		onUpdateField: PropTypes.func,
+		onFormErrorsUpdate: PropTypes.func,
+	};
 
-  updateItem = (item) => {
-    this.props.onUpdateField(item);
-  }
+	updateItem = item => {
+		this.props.onUpdateField(item);
+	};
 
-  render() {
-    const value = this.props.fieldValue || {
-      title: "",
-      body: ""
-    };
-    return (
-      <div className="form__field">
-        <ManagedForm data={value} updateData={this.updateItem} onFormErrorsUpdate={this.props.onFormErrorsUpdate} formName="qaEditor">
-          <ManagedField fieldLocation="body" name="Answer" isRequired={true}>
-            <FormFieldsScribeEditor
-              showWordCount={true}
-              suggestedLength={WordLimit}
-              showToolbar={true}
-              tooLongMsg={<div>Heads up. <strong>You've exceeded the {WordLimit} word limit for this field.</strong> You can still publish it, but bear in mind that atoms should be concise.</div>} />
-          </ManagedField>
-        </ManagedForm>
-      </div>
-    );
-  }
+	render() {
+		const value = this.props.fieldValue || {
+			title: '',
+			body: '',
+		};
+		return (
+			<div className="form__field">
+				<ManagedForm
+					data={value}
+					updateData={this.updateItem}
+					onFormErrorsUpdate={this.props.onFormErrorsUpdate}
+					formName="qaEditor"
+				>
+					<ManagedField fieldLocation="body" name="Answer" isRequired={true}>
+						<FormFieldsScribeEditor
+							showWordCount={true}
+							showToolbar={true}
+							suggestedLength={wordLimits.qanda}
+							tooLongMsg={tooLongMsg}
+						/>
+					</ManagedField>
+				</ManagedForm>
+			</div>
+		);
+	}
 }

--- a/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
@@ -39,7 +39,7 @@ export class QAItem extends React.Component {
 							showWordCount={true}
 							showToolbar={true}
 							suggestedLength={wordLimits.qanda}
-							tooLongMsg={tooLongMsg}
+							tooLongMsg={tooLongMsg(wordLimits.qanda)}
 						/>
 					</ManagedField>
 				</ManagedForm>

--- a/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
+++ b/public/js/components/AtomEdit/CustomEditors/QAndAFields/QAItem.js
@@ -1,49 +1,49 @@
-import React, { PropTypes } from 'react';
-import { ManagedForm, ManagedField } from '../../../ManagedEditor';
-import FormFieldsScribeEditor from '../../../FormFields/FormFieldScribeEditor';
-import { wordLimits, tooLongMsg } from '../../../../util/wordLimits';
+import React, { PropTypes } from "react";
+import { ManagedForm, ManagedField } from "../../../ManagedEditor";
+import FormFieldsScribeEditor from "../../../FormFields/FormFieldScribeEditor";
+import { wordLimits, tooLongMsg } from "../../../../util/wordLimits";
 
 export class QAItem extends React.Component {
-	static propTypes = {
-		fieldLabel: PropTypes.string,
-		fieldName: PropTypes.string,
-		fieldValue: PropTypes.shape({
-			title: PropTypes.string,
-			date: PropTypes.date,
-			body: PropTypes.string,
-		}),
-		fieldPlaceholder: PropTypes.string,
-		onUpdateField: PropTypes.func,
-		onFormErrorsUpdate: PropTypes.func,
-	};
+  static propTypes = {
+    fieldLabel: PropTypes.string,
+    fieldName: PropTypes.string,
+    fieldValue: PropTypes.shape({
+      title: PropTypes.string,
+      date: PropTypes.date,
+      body: PropTypes.string,
+    }),
+    fieldPlaceholder: PropTypes.string,
+    onUpdateField: PropTypes.func,
+    onFormErrorsUpdate: PropTypes.func,
+  };
 
-	updateItem = item => {
-		this.props.onUpdateField(item);
-	};
+  updateItem = item => {
+    this.props.onUpdateField(item);
+  };
 
-	render() {
-		const value = this.props.fieldValue || {
-			title: '',
-			body: '',
-		};
-		return (
-			<div className="form__field">
-				<ManagedForm
-					data={value}
-					updateData={this.updateItem}
-					onFormErrorsUpdate={this.props.onFormErrorsUpdate}
-					formName="qaEditor"
-				>
-					<ManagedField fieldLocation="body" name="Answer" isRequired={true}>
-						<FormFieldsScribeEditor
-							showWordCount={true}
-							showToolbar={true}
-							suggestedLength={wordLimits.qanda}
-							tooLongMsg={tooLongMsg(wordLimits.qanda)}
-						/>
-					</ManagedField>
-				</ManagedForm>
-			</div>
-		);
-	}
+  render() {
+    const value = this.props.fieldValue || {
+      title: "",
+      body: "",
+    };
+    return (
+      <div className="form__field">
+        <ManagedForm
+          data={value}
+          updateData={this.updateItem}
+          onFormErrorsUpdate={this.props.onFormErrorsUpdate}
+          formName="qaEditor"
+        >
+          <ManagedField fieldLocation="body" name="Answer" isRequired={true}>
+            <FormFieldsScribeEditor
+              showWordCount={true}
+              showToolbar={true}
+              suggestedLength={wordLimits.qanda}
+              tooLongMsg={tooLongMsg(wordLimits.qanda)}
+            />
+          </ManagedField>
+        </ManagedForm>
+      </div>
+    );
+  }
 }

--- a/public/js/util/uriEncodeParams.js
+++ b/public/js/util/uriEncodeParams.js
@@ -1,11 +1,11 @@
 export const uriEncodeParams = params => {
-	return Object.keys(params)
-		.map(k => `${encodeURIComponent(k)}=${encodeURIComponent(params[k])}`)
-		.join('&');
+  return Object.keys(params)
+    .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(params[k])}`)
+    .join('&');
 };
 
 export const sanitiseQuery = query => {
-	return Object.keys(query)
-		.filter(k => query[k] && query[k].length != 0)
-		.reduce((res, key) => ((res[key] = query[key]), res), {});
+  return Object.keys(query)
+    .filter(k => query[k] && query[k].length != 0)
+    .reduce((res, key) => ((res[key] = query[key]), res), {});
 };

--- a/public/js/util/uriEncodeParams.js
+++ b/public/js/util/uriEncodeParams.js
@@ -1,11 +1,11 @@
-export const uriEncodeParams = (params) => {
-    return Object.keys(params)
-        .map(k => `${encodeURIComponent(k)}=${encodeURIComponent(params[k])}`)
-        .join('&');
+export const uriEncodeParams = params => {
+	return Object.keys(params)
+		.map(k => `${encodeURIComponent(k)}=${encodeURIComponent(params[k])}`)
+		.join('&');
 };
 
-export const sanitiseQuery = (query) => {
-  return Object.keys(query)
-  .filter(k => (query[k] && query[k].length != 0))
-  .reduce( (res, key) => (res[key] = query[key], res), {} );
+export const sanitiseQuery = query => {
+	return Object.keys(query)
+		.filter(k => query[k] && query[k].length != 0)
+		.reduce((res, key) => ((res[key] = query[key]), res), {});
 };

--- a/public/js/util/validators.js
+++ b/public/js/util/validators.js
@@ -8,44 +8,44 @@ import { wordLimits } from './wordLimits';
  **/
 
 export const isHttpsUrl = value => {
-	const stringValue = typeof value === 'string' ? value : '';
-	if (
-		stringValue.match(
-			/^(https:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/
-		)
-	) {
-		return Promise.resolve(true);
-	} else {
-		const error = new FieldError('not-https', 'Not a HTTPS url');
-		return Promise.resolve(error);
-	}
+  const stringValue = typeof value === 'string' ? value : '';
+  if (
+    stringValue.match(
+      /^(https:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/
+    )
+  ) {
+    return Promise.resolve(true);
+  } else {
+    const error = new FieldError('not-https', 'Not a HTTPS url');
+    return Promise.resolve(error);
+  }
 };
 
 export const checkItemsUnderWordCount = values => {
-	if (values.length > 0) {
-		var wordCount = values.map(function(itemData) {
-			var strippedText = stripHtml(itemData.body);
-			return strippedText.split(' ').length;
-		});
+  if (values.length > 0) {
+    var wordCount = values.map(function(itemData) {
+      var strippedText = stripHtml(itemData.body);
+      return strippedText.split(' ').length;
+    });
 
-		var totalCount = wordCount.reduce(function(total, num) {
-			return total + num;
-		});
+    var totalCount = wordCount.reduce(function(total, num) {
+      return total + num;
+    });
 
-		if (totalCount <= wordLimits.default) {
-			return Promise.resolve(true);
-		} else {
-			const error = new FieldError(
-				'too-long',
-				`You\'ve reached the word limit on this atom type. Please edit your items to less than a total of ${
-					wordLimits.default
-				} words.`
-			);
-			return Promise.resolve(error);
-		}
-	}
+    if (totalCount <= wordLimits.default) {
+      return Promise.resolve(true);
+    } else {
+      const error = new FieldError(
+        'too-long',
+        `You\'ve reached the word limit on this atom type. Please edit your items to less than a total of ${
+          wordLimits.default
+        } words.`
+      );
+      return Promise.resolve(error);
+    }
+  }
 };
 
 function stripHtml(rawBody) {
-	return rawBody.replace(/<{1}[^<>]{1,}>{1}/g, '');
+  return rawBody.replace(/<{1}[^<>]{1,}>{1}/g, '');
 }

--- a/public/js/util/validators.js
+++ b/public/js/util/validators.js
@@ -1,44 +1,51 @@
 import FieldError from '../constants/FieldError';
+import { wordLimits } from './wordLimits';
+
 /**
  *
  * Validator should return a promise resolved with true for a pass and a new FieldError('error', 'message') if false
  *
  **/
 
-
-export const isHttpsUrl = (value) => {
-  const stringValue = typeof value === 'string' ? value : '';
-  if (stringValue.match(/^(https:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/)) {
-    return Promise.resolve(true);
-  } else {
-    const error = new FieldError('not-https', 'Not a HTTPS url');
-    return Promise.resolve(error);
-  }
+export const isHttpsUrl = value => {
+	const stringValue = typeof value === 'string' ? value : '';
+	if (
+		stringValue.match(
+			/^(https:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/
+		)
+	) {
+		return Promise.resolve(true);
+	} else {
+		const error = new FieldError('not-https', 'Not a HTTPS url');
+		return Promise.resolve(error);
+	}
 };
 
-const WordLimit = 400;
-export const checkItemsUnderWordCount = (values) => {
-    if (values.length > 0) {
-        var wordCount = values.map(function(itemData) {
-            var strippedText = stripHtml(itemData.body);
-            return strippedText.split(" ").length;
-        });
+export const checkItemsUnderWordCount = values => {
+	if (values.length > 0) {
+		var wordCount = values.map(function(itemData) {
+			var strippedText = stripHtml(itemData.body);
+			return strippedText.split(' ').length;
+		});
 
-        var totalCount = wordCount.reduce(function (total, num) {
-            return total + num;
-        });
+		var totalCount = wordCount.reduce(function(total, num) {
+			return total + num;
+		});
 
-        if (totalCount <= WordLimit) {
-            return Promise.resolve(true);
-        } else {
-            const error = new FieldError('too-long', `You\'ve reached the word limit on this atom type. Please edit your items to less than a total of ${WordLimit} words.`);
-            return Promise.resolve(error);
-        }
-
-    }
+		if (totalCount <= wordLimits.default) {
+			return Promise.resolve(true);
+		} else {
+			const error = new FieldError(
+				'too-long',
+				`You\'ve reached the word limit on this atom type. Please edit your items to less than a total of ${
+					wordLimits.default
+				} words.`
+			);
+			return Promise.resolve(error);
+		}
+	}
 };
 
 function stripHtml(rawBody) {
-  return rawBody.replace(/<{1}[^<>]{1,}>{1}/g,"");
+	return rawBody.replace(/<{1}[^<>]{1,}>{1}/g, '');
 }
-

--- a/public/js/util/wordLimits.js
+++ b/public/js/util/wordLimits.js
@@ -1,11 +1,14 @@
+import React from 'react';
+
 export const wordLimits = {
 	default: 400,
 	qanda: 250,
 };
-export const tooLongMsg = (
+
+export const tooLongMsg = wordLimit => (
 	<div>
 		Heads up.{' '}
-		<strong>You've exceeded the {WordLimit} word limit for this field.</strong>{' '}
+		<strong>You've exceeded the {wordLimit} word limit for this field.</strong>{' '}
 		You can still publish it, but bear in mind that atoms should be concise.
 	</div>
 );

--- a/public/js/util/wordLimits.js
+++ b/public/js/util/wordLimits.js
@@ -1,14 +1,14 @@
-import React from 'react';
+import React from "react";
 
 export const wordLimits = {
-	default: 400,
-	qanda: 250,
+  default: 400,
+  qanda: 250,
 };
 
 export const tooLongMsg = wordLimit => (
-	<div>
-		Heads up.{' '}
-		<strong>You've exceeded the {wordLimit} word limit for this field.</strong>{' '}
-		You can still publish it, but bear in mind that atoms should be concise.
-	</div>
+  <div>
+    Heads up.{" "}
+    <strong>You've exceeded the {wordLimit} word limit for this field.</strong>{" "}
+    You can still publish it, but bear in mind that atoms should be concise.
+  </div>
 );

--- a/public/js/util/wordLimits.jsx
+++ b/public/js/util/wordLimits.jsx
@@ -1,0 +1,11 @@
+export const wordLimits = {
+	default: 400,
+	qanda: 250,
+};
+export const tooLongMsg = (
+	<div>
+		Heads up.{' '}
+		<strong>You've exceeded the {WordLimit} word limit for this field.</strong>{' '}
+		You can still publish it, but bear in mind that atoms should be concise.
+	</div>
+);


### PR DESCRIPTION
We only have the new style error messages in QnA snippets. This brings the new messaging over to the guide snippets and a followup pr will bring it to the other 2

<img width="494" alt="Screenshot 2019-05-10 at 15 17 35" src="https://user-images.githubusercontent.com/11539094/57533925-c1e5c580-7336-11e9-9626-aac9fdb81a39.png">
