### PR TITLE
Display tag's internal name

### DIFF
--- a/public/js/components/FormFields/FormFieldTagPicker.js
+++ b/public/js/components/FormFields/FormFieldTagPicker.js
@@ -80,7 +80,7 @@ export default class FormFieldTagPicker extends React.Component {
           };
 
           return (
-            <a className="form__field__suggestion" key={suggestion.id} title={suggestion.id} onClick={updateFn}>{suggestion.webTitle} ({suggestion.type})</a>
+            <a className="form__field__suggestion" key={suggestion.id} title={suggestion.id} onClick={updateFn}>{suggestion.internalName} ({suggestion.type})</a>
           );
         })}
       </div>

--- a/public/js/components/FormFields/FormFieldTagPicker.js
+++ b/public/js/components/FormFields/FormFieldTagPicker.js
@@ -80,7 +80,7 @@ export default class FormFieldTagPicker extends React.Component {
           };
 
           return (
-            <a className="form__field__suggestion" key={suggestion.id} title={suggestion.id} onClick={updateFn}>{suggestion.internalName} ({suggestion.type})</a>
+            <a className="form__field__suggestion" key={suggestion.id} title={suggestion.id} onClick={updateFn}>{suggestion.internalName || suggestion.webTitle} ({suggestion.type})</a>
           );
         })}
       </div>


### PR DESCRIPTION
Use tags' internal name instead of web title when displaying autocomplete results, if it is available.