### PR TITLE
Make snippets require tagging

### DIFF
--- a/public/js/components/AtomEmbed/AtomEmbed.js
+++ b/public/js/components/AtomEmbed/AtomEmbed.js
@@ -3,6 +3,7 @@ import { atomPropType } from '../../constants/atomPropType.js';
 import copy from 'copy-to-clipboard';
 import { Link } from 'react-router';
 import Workflow from '../Workflow/Workflow';
+import { doesAtomTypeRequireTagging } from '../../constants/atomData';
 
 import CurrentTargets from './CurrentTargets';
 
@@ -93,7 +94,10 @@ class AtomEmbed extends React.Component {
             />
           </div>
           <div className="form__row">
-            <h3 className="form__subheading">Tag This Atom *</h3>
+            <h3 className="form__subheading">
+              Tag This Atom
+              {doesAtomTypeRequireTagging(this.props.atom.atomType) && ' *'}
+            </h3>
             <div className="form__row">
               <CurrentTargets atom={this.props.atom} />
             </div>

--- a/public/js/components/AtomEmbed/AtomEmbed.js
+++ b/public/js/components/AtomEmbed/AtomEmbed.js
@@ -1,57 +1,60 @@
-import React, {PropTypes} from 'react';
-import {atomPropType} from '../../constants/atomPropType.js';
+import React, { PropTypes } from 'react';
+import { atomPropType } from '../../constants/atomPropType.js';
 import copy from 'copy-to-clipboard';
-import {Link} from 'react-router';
+import { Link } from 'react-router';
 import Workflow from '../Workflow/Workflow';
 
 import CurrentTargets from './CurrentTargets';
 
 class AtomEmbed extends React.Component {
-
   static propTypes = {
     atom: atomPropType,
     config: PropTypes.shape({
       capiLiveUrl: PropTypes.string.isRequired,
-      isEmbedded: PropTypes.bool.isRequired
+      isEmbedded: PropTypes.bool.isRequired,
     }),
     workflowActions: PropTypes.shape({
       getWorkflowStatus: PropTypes.func.isRequired,
-      trackInWorkflow: PropTypes.func.isRequired
+      trackInWorkflow: PropTypes.func.isRequired,
     }),
-    workflow: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({
-      title: PropTypes.string,
-      prodOffice: PropTypes.string,
-      section: PropTypes.string,
-      status: PropTypes.string,
-      scheduledLaunch: PropTypes.string
-    })])
-  }
+    workflow: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.shape({
+        title: PropTypes.string,
+        prodOffice: PropTypes.string,
+        section: PropTypes.string,
+        status: PropTypes.string,
+        scheduledLaunch: PropTypes.string,
+      }),
+    ]),
+  };
 
   state = {
-    copied: false
-  }
+    copied: false,
+  };
 
   generateEmbedUrl() {
     if (!this.props.atom) {
-      return "";
+      return '';
     }
 
     const atom = this.props.atom;
-    return `${this.props.config.capiLiveUrl}/atom/${atom.atomType.toLowerCase()}/${atom.id}`;
+    return `${
+      this.props.config.capiLiveUrl
+    }/atom/${atom.atomType.toLowerCase()}/${atom.id}`;
   }
 
   copyUrl = () => {
     copy(this.generateEmbedUrl());
 
-    this.setState({copied: true});
+    this.setState({ copied: true });
 
     setTimeout(() => {
-      this.setState({copied: false});
+      this.setState({ copied: false });
     }, 5000);
-  }
+  };
 
-  render () {
-
+  render() {
     if (this.props.config.isEmbedded) {
       return false;
     }
@@ -66,26 +69,42 @@ class AtomEmbed extends React.Component {
           <div className="form__row">
             <h3 className="form__subheading">Embed This Atom</h3>
             <div className="form__row">
-              <label htmlFor="embedUrl" className="form__label">Embed URL</label>
-              <input id="embedUrl" className="form__field" value={this.generateEmbedUrl()} readOnly={true}/>
+              <label htmlFor="embedUrl" className="form__label">
+                Embed URL
+              </label>
+              <input
+                id="embedUrl"
+                className="form__field"
+                value={this.generateEmbedUrl()}
+                readOnly={true}
+              />
               <button className="btn" onClick={this.copyUrl}>
-                {this.state.copied ? "Copied!" : "Copy URL"}
+                {this.state.copied ? 'Copied!' : 'Copy URL'}
               </button>
             </div>
           </div>
           <div className="form__row">
             <h3 className="form__subheading">Workflow</h3>
-            <Workflow atom={this.props.atom} config={this.props.config} workflow={this.props.workflow} workflowActions={this.props.workflowActions}/>
+            <Workflow
+              atom={this.props.atom}
+              config={this.props.config}
+              workflow={this.props.workflow}
+              workflowActions={this.props.workflowActions}
+            />
           </div>
           <div className="form__row">
-            <h3 className="form__subheading">Suggest This Atom</h3>
+            <h3 className="form__subheading">Tag This Atom *</h3>
             <div className="form__row">
               <CurrentTargets atom={this.props.atom} />
             </div>
           </div>
           <div className="form__row">
-            <Link to={`/atoms/${this.props.atom.atomType}/${this.props.atom.id}/stats`}
-                  className="atom-list__link">
+            <Link
+              to={`/atoms/${this.props.atom.atomType}/${
+                this.props.atom.id
+              }/stats`}
+              className="atom-list__link"
+            >
               Where has this atom been used?
             </Link>
           </div>

--- a/public/js/components/AtomEmbed/AtomEmbed.js
+++ b/public/js/components/AtomEmbed/AtomEmbed.js
@@ -95,7 +95,7 @@ class AtomEmbed extends React.Component {
           </div>
           <div className="form__row">
             <h3 className="form__subheading">
-              Tag This Atom
+              Tags
               {doesAtomTypeRequireTagging(this.props.atom.atomType) && ' *'}
             </h3>
             <div className="form__row">

--- a/public/js/components/AtomEmbed/CurrentTargets.js
+++ b/public/js/components/AtomEmbed/CurrentTargets.js
@@ -9,10 +9,11 @@ import distanceInWordsToNow from 'date-fns/distance_in_words_to_now';
 import CreateTargetForm from './CreateTargetForm';
 import { connect } from 'react-redux';
 import { updateFormErrors } from '../../actions/FormErrorActions/updateFormErrors';
+import { doesAtomTypeRequireTagging } from '../../constants/atomData';
 
 const taggingRequiredError = {
   title: 'required',
-  message: 'Please suggest at least one tag for this atom',
+  message: 'Please add at least one tag for this atom',
 };
 
 class CurrentTargets extends React.Component {
@@ -47,14 +48,16 @@ class CurrentTargets extends React.Component {
   };
 
   componentDidUpdate = () => {
-    this.props.dispatch(
-      updateFormErrors({
-        currentTargets: {
-          'Tagging required':
-            this.state.targets.length > 0 ? [] : [taggingRequiredError],
-        },
-      })
-    );
+    if (doesAtomTypeRequireTagging(this.props.atom.atomType)) {
+      this.props.dispatch(
+        updateFormErrors({
+          currentTargets: {
+            'Tagging required':
+              this.state.targets.length > 0 ? [] : [taggingRequiredError],
+          },
+        })
+      );
+    }
   };
 
   toggleEditMode = () => {
@@ -133,7 +136,4 @@ class CurrentTargets extends React.Component {
   }
 }
 
-export default connect(
-  null,
-  null
-)(CurrentTargets);
+export default connect()(CurrentTargets);

--- a/public/js/components/AtomEmbed/CurrentTargets.js
+++ b/public/js/components/AtomEmbed/CurrentTargets.js
@@ -13,7 +13,7 @@ import { doesAtomTypeRequireTagging } from '../../constants/atomData';
 
 const taggingRequiredError = {
   title: 'required',
-  message: 'Please add at least one tag for this atom',
+  message: 'You must add at least one tag before publishing your atom',
 };
 
 class CurrentTargets extends React.Component {
@@ -52,7 +52,7 @@ class CurrentTargets extends React.Component {
       this.props.dispatch(
         updateFormErrors({
           currentTargets: {
-            'Tagging required':
+            'Tags required':
               this.state.targets.length > 0 ? [] : [taggingRequiredError],
           },
         })

--- a/public/js/components/AtomEmbed/CurrentTargets.js
+++ b/public/js/components/AtomEmbed/CurrentTargets.js
@@ -1,21 +1,31 @@
-import React from 'react';
-import {atomPropType} from '../../constants/atomPropType';
-import {fetchTargetsForAtomPath, deleteTarget} from '../../services/TargetingApi';
+import React, { PropTypes } from 'react';
+import { atomPropType } from '../../constants/atomPropType';
+import {
+  fetchTargetsForAtomPath,
+  deleteTarget,
+} from '../../services/TargetingApi';
 import distanceInWordsToNow from 'date-fns/distance_in_words_to_now';
 
 import CreateTargetForm from './CreateTargetForm';
+import { connect } from 'react-redux';
+import { updateFormErrors } from '../../actions/FormErrorActions/updateFormErrors';
+
+const taggingRequiredError = {
+  title: 'required',
+  message: 'Please suggest at least one tag for this atom',
+};
 
 class CurrentTargets extends React.Component {
-
   static propTypes = {
     atom: atomPropType,
-  }
+    dispatch: PropTypes.func,
+  };
 
   state = {
     targets: [],
     fetching: false,
-    editing: false
-  }
+    editing: false,
+  };
 
   componentDidMount() {
     this.fetchTargets();
@@ -24,47 +34,67 @@ class CurrentTargets extends React.Component {
   calculateAtomPath = () => {
     const atom = this.props.atom;
     return `/atom/${atom.atomType.toLowerCase()}/${atom.id}`;
-  }
+  };
 
   fetchTargets = () => {
-    this.setState({fetching: true});
-    fetchTargetsForAtomPath(this.calculateAtomPath()).then((targets) => {
+    this.setState({ fetching: true });
+    fetchTargetsForAtomPath(this.calculateAtomPath()).then(targets => {
       this.setState({
         targets: targets,
-        fetching: false
+        fetching: false,
       });
     });
-  }
+  };
+
+  componentDidUpdate = () => {
+    this.props.dispatch(
+      updateFormErrors({
+        currentTargets: {
+          'Tagging required':
+            this.state.targets.length > 0 ? [] : [taggingRequiredError],
+        },
+      })
+    );
+  };
 
   toggleEditMode = () => {
     this.setState({
       editing: !this.state.editing,
-      currentTarget: {}
+      currentTarget: {},
     });
-  }
+  };
 
-  deleteTarget = (target) => {
+  deleteTarget = target => {
     deleteTarget(target.id).then(() => {
       this.fetchTargets();
     });
-  }
+  };
 
   renderTarget = (target, i) => {
     return (
       <div className="targeting__target">
-        <div className="targeting__target__title">
-          Target {i + 1}
-        </div>
-        <a className="targeting__target__delete" onClick={this.deleteTarget.bind(this, target)}>
-            <img className="targeting__target__delete"src="/assets/images/delete-icon.svg"/>
+        <div className="targeting__target__title">Target {i + 1}</div>
+        <a
+          className="targeting__target__delete"
+          onClick={this.deleteTarget.bind(this, target)}
+        >
+          <img
+            className="targeting__target__delete"
+            src="/assets/images/delete-icon.svg"
+          />
         </a>
         <ul className="targeting__target__tags">
-          {target.tagPaths.map((tagPath) => <li key={tagPath}>{tagPath}</li>)}
+          {target.tagPaths.map(tagPath => (
+            <li key={tagPath}>{tagPath}</li>
+          ))}
         </ul>
-        <div>Expires {distanceInWordsToNow(target.activeUntil, {addSuffix: true})} </div>
+        <div>
+          Expires{' '}
+          {distanceInWordsToNow(target.activeUntil, { addSuffix: true })}{' '}
+        </div>
       </div>
     );
-  }
+  };
 
   renderTargets() {
     if (this.state.fetching) {
@@ -80,26 +110,30 @@ class CurrentTargets extends React.Component {
         {this.state.targets.map(this.renderTarget)}
       </div>
     );
-
   }
 
-  render () {
+  render() {
     return (
       <div className="targeting">
         {this.renderTargets()}
-        {this.state.editing ?
+        {this.state.editing ? (
           <CreateTargetForm
             atomPath={this.calculateAtomPath()}
             title={this.props.atom.title}
             triggerTargetFetch={this.fetchTargets}
             toggleEditMode={this.toggleEditMode}
-            />
-          :
-          <button className="btn" onClick={this.toggleEditMode}>Create Target</button>
-        }
+          />
+        ) : (
+          <button className="btn" onClick={this.toggleEditMode}>
+            Create Target
+          </button>
+        )}
       </div>
     );
   }
 }
 
-export default CurrentTargets;
+export default connect(
+  null,
+  null
+)(CurrentTargets);

--- a/public/js/constants/atomData.js
+++ b/public/js/constants/atomData.js
@@ -6,121 +6,169 @@
 //createUri - a lodash template that will be passed gutoolsDomain.
 //statsUrl - a lodash template that will be passed atomId, atomType
 
-
-import {PropTypes} from 'react';
+import { PropTypes } from 'react';
 import _template from 'lodash/fp/template';
-import {logInfo} from '../util/logger';
+import { logInfo } from '../util/logger';
 import { getStore } from '../util/storeAccessor';
 
-
 export const cta = {
-  type: "cta",
-  fullName: "Call To Action",
-  description: "A call to action designed for use in GLabs Hosted Content",
+  type: 'cta',
+  fullName: 'Call To Action',
+  description: 'A call to action designed for use in GLabs Hosted Content',
 };
 
 export const recipe = {
-  type: "recipe",
-  fullName: "Recipe",
-  description: "Structured recipes for better website presentation within articles",
+  type: 'recipe',
+  fullName: 'Recipe',
+  description:
+    'Structured recipes for better website presentation within articles',
 };
 
 export const storyQuestions = {
-  type: "storyquestions",
-  fullName: "Reader Questions",
-  description: "Pose further questions to the audience and gather interest",
-  statsUrl: _template("https://dashboard.ophan.co.uk/interaction/storyQuestions?days=7&platform=all&atom-id=${atomId}")
+  type: 'storyquestions',
+  fullName: 'Reader Questions',
+  description: 'Pose further questions to the audience and gather interest',
+  statsUrl: _template(
+    'https://dashboard.ophan.co.uk/interaction/storyQuestions?days=7&platform=all&atom-id=${atomId}'
+  ),
 };
 
 export const quiz = {
-  type: "quiz",
-  fullName: "Quiz",
-  description: "Questions and Answer format, allowing both knowledge and personality type quizzes",
-  editorUri: _template("https://quizzes.${gutoolsDomain}/quiz/${atomId}"),
-  createUri: _template("https://quizzes.${gutoolsDomain}")
+  type: 'quiz',
+  fullName: 'Quiz',
+  description:
+    'Questions and Answer format, allowing both knowledge and personality type quizzes',
+  editorUri: _template('https://quizzes.${gutoolsDomain}/quiz/${atomId}'),
+  createUri: _template('https://quizzes.${gutoolsDomain}'),
 };
 
 export const media = {
-  type: "media",
-  fullName: "Video",
-  description: "A Guardian produced video, with rich tracking and thumbnail. Generally hosted on YouTube",
-  editorUri: _template("https://video.${gutoolsDomain}/videos/${atomId}"),
-  createUri: _template("https://video.${gutoolsDomain}/videos/create")
+  type: 'media',
+  fullName: 'Video',
+  description:
+    'A Guardian produced video, with rich tracking and thumbnail. Generally hosted on YouTube',
+  editorUri: _template('https://video.${gutoolsDomain}/videos/${atomId}'),
+  createUri: _template('https://video.${gutoolsDomain}/videos/create'),
 };
 
 export const qa = {
-  type: "qanda",
-  fullName: "Q & A",
-  description: "A <b>single</b> question with a <b>single</b> answer"
+  type: 'qanda',
+  fullName: 'Q & A',
+  description: 'A <b>single</b> question with a <b>single</b> answer',
 };
 
 export const guide = {
-  type: "guide",
-  fullName: "Quick Guide",
-  description: "<b>Multiple</b> questions and answers on a single theme"
+  type: 'guide',
+  fullName: 'Quick Guide',
+  description: '<b>Multiple</b> questions and answers on a single theme',
 };
 
 export const profile = {
-  type: "profile",
-  fullName: "Profile",
-  description: "A quick guide for a person or institution"
+  type: 'profile',
+  fullName: 'Profile',
+  description: 'A quick guide for a person or institution',
 };
 
 export const timeline = {
-  type: "timeline",
-  fullName: "Timeline",
-  description: "A series of key events to help readers navigate an ongoing story"
+  type: 'timeline',
+  fullName: 'Timeline',
+  description:
+    'A series of key events to help readers navigate an ongoing story',
 };
 
 export const explainer = {
-  type: "explainer",
-  fullName: "Explainer Text",
-  description: "Edit legacy Explainer snippets - (creating new ones is not supported)",
+  type: 'explainer',
+  fullName: 'Explainer Text',
+  description:
+    'Edit legacy Explainer snippets - (creating new ones is not supported)',
 };
 
 export const commonsDivision = {
-  type: "commonsdivision",
-  fullName: "Commons Division",
-  description: "House of Commons division results"
+  type: 'commonsdivision',
+  fullName: 'Commons Division',
+  description: 'House of Commons division results',
 };
 
 export const chart = {
-  type: "chart",
-  fullName: "Chart",
-  description: "A variety of different charts"
+  type: 'chart',
+  fullName: 'Chart',
+  description: 'A variety of different charts',
 };
 
 export const audio = {
-  type: "audio",
-  fullName: "Audio",
-  description: "An audio player for clips or full podcasts"
+  type: 'audio',
+  fullName: 'Audio',
+  description: 'An audio player for clips or full podcasts',
 };
 
-
-export const allAtomTypes = [cta, recipe, qa, guide, profile, timeline, media, chart, audio,  storyQuestions, quiz, explainer, commonsDivision];
-export const workshopEditableAtomTypes = [cta, storyQuestions, recipe, qa, guide, profile, timeline, explainer, commonsDivision, chart, audio];
+export const allAtomTypes = [
+  cta,
+  recipe,
+  qa,
+  guide,
+  profile,
+  timeline,
+  media,
+  chart,
+  audio,
+  storyQuestions,
+  quiz,
+  explainer,
+  commonsDivision,
+];
+export const workshopEditableAtomTypes = [
+  cta,
+  storyQuestions,
+  recipe,
+  qa,
+  guide,
+  profile,
+  timeline,
+  explainer,
+  commonsDivision,
+  chart,
+  audio,
+];
 
 export const snippetAtomTypes = [qa, guide, profile, timeline];
 export const legacyAtomTypes = [explainer];
 
 export function getNonEditableAtomTypes() {
-   return allAtomTypes.filter((atomType) => {
-     return !workshopEditableAtomTypes.includes(atomType) && !legacyAtomTypes.includes(atomType);
-   });
+  return allAtomTypes.filter(atomType => {
+    return (
+      !workshopEditableAtomTypes.includes(atomType) &&
+      !legacyAtomTypes.includes(atomType)
+    );
+  });
 }
 
-export const editableNonSnippetAtomTypes =
-  workshopEditableAtomTypes.filter((atomType) => {
-    return !snippetAtomTypes.includes(atomType) && !legacyAtomTypes.includes(atomType);
-  });
+export const editableNonSnippetAtomTypes = workshopEditableAtomTypes.filter(
+  atomType => {
+    return (
+      !snippetAtomTypes.includes(atomType) &&
+      !legacyAtomTypes.includes(atomType)
+    );
+  }
+);
 
 export function getAtomByType(typeString) {
-  return allAtomTypes.find((atomData) => atomData.type.toLowerCase() === typeString.toLowerCase());
+  return allAtomTypes.find(
+    atomData => atomData.type.toLowerCase() === typeString.toLowerCase()
+  );
 }
 
 export function isAtomTypeEditable(typeString) {
-  const matchingType = workshopEditableAtomTypes.find((atomData) => atomData.type.toLowerCase() === typeString.toLowerCase());
+  const matchingType = workshopEditableAtomTypes.find(
+    atomData => atomData.type.toLowerCase() === typeString.toLowerCase()
+  );
   return !!matchingType;
+}
+
+export function doesAtomTypeRequireTagging(typeString) {
+  console.log(typeString);
+  return snippetAtomTypes.find(
+    atomData => atomData.type.toLowerCase() === typeString.toLowerCase()
+  );
 }
 
 export function getCreateUrlFromAtomType(atomType) {
@@ -135,7 +183,7 @@ export function getCreateUrlFromAtomType(atomType) {
   const state = store.getState();
 
   return atomType.createUri({
-    gutoolsDomain: state.config.atomEditorGutoolsDomain
+    gutoolsDomain: state.config.atomEditorGutoolsDomain,
   });
 }
 
@@ -143,5 +191,5 @@ export function getCreateUrlFromAtomType(atomType) {
 export const AtomTypePropType = PropTypes.shape({
   type: PropTypes.string.isRequired,
   fullName: PropTypes.string.isRequired,
-  description: PropTypes.string.isRequired
+  description: PropTypes.string.isRequired,
 });

--- a/public/js/constants/atomData.js
+++ b/public/js/constants/atomData.js
@@ -165,7 +165,6 @@ export function isAtomTypeEditable(typeString) {
 }
 
 export function doesAtomTypeRequireTagging(typeString) {
-  console.log(typeString);
   return snippetAtomTypes.find(
     atomData => atomData.type.toLowerCase() === typeString.toLowerCase()
   );


### PR DESCRIPTION
BOOSH

*As an editorial user, I want to be able to find existing atoms in Composer, so that I can efficiently re-use existing content.*

**Issue**
Many atoms are being created without tags. The result is that they don't appear on Composer / Proposer. 

<img width="293" alt="Screenshot 2019-05-17 at 13 19 52" src="https://user-images.githubusercontent.com/11539094/57927735-da119380-78a6-11e9-80c3-bc913e11682e.png">
<img width="296" alt="Screenshot 2019-05-17 at 13 20 06" src="https://user-images.githubusercontent.com/11539094/57927737-dbdb5700-78a6-11e9-944f-19f3b64edaf7.png">
