### PR TITLE
Ensure a duration is present when importing an audio episode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ for both the composer and capi AWS accounts from [janus](https://janus.gutools.c
 
  - Fetch config from S3: `./fetch-config.sh`
  - If you get an error message saying that you requred AWS Signature Version 4, configure your aws cli by running `aws configure set default.s3.signature_version s3v4`
- - Setup the nginx mapping by following the instructions in the
+ - Setup the nginx mapping by following the instructions in the "Install config for an application" section of the 
  [dev-nginx readme](https://github.com/guardian/dev-nginx#install-config-for-an-application).
+ 
+    tl;dr? Try this...
+    * Clone the [dev-nginx](https://github.com/guardian/dev-nginx) private repo to your machine (e.g. ~/code/dev-nginx)
+    * Change directory to that location: `cd ~/code/dev-nginx`
+    * Assuming your copy of atom-workshop is in ~/code/atom-workshop, run `sudo ./setup-app.rb ~/code/atom-workshop/nginx/nginx-mapping.yml`
+    
  - Install Client Side Dependencies with `./scripts/setup.sh`
  - Run app with: `./scripts/start.sh`
  - Run using sbt: `sbt "run 9050"`. (For quick restart you should run `sbt` and then `run 9050`, so that you can exit

--- a/public/js/actions/AtomActions/getAudioPageData.js
+++ b/public/js/actions/AtomActions/getAudioPageData.js
@@ -50,9 +50,12 @@ function extractFields (audioPage) {
   let audioAsset = audioEl.assets.find(asset => asset.type === "audio");
   let storyImage = audioPage.fields.thumbnail || "";
 
-  let durationSeconds = audioAsset ? parseInt(audioAsset.typeData.durationMinutes) * 60 + parseInt(audioAsset.typeData.durationSeconds) : 0;
-  let trackUrl = audioAsset ? audioAsset.file : "";
-  let contentId = audioEl ? audioEl.id : "";
+  let durationSeconds = (audioAsset && audioAsset.typeData) ?
+    parseInt(audioAsset.typeData.durationMinutes || 0) * 60 + parseInt(audioAsset.typeData.durationSeconds || 0) :
+    0;
+
+  let trackUrl = audioAsset ? (audioAsset.file || "") : "";
+  let contentId = audioEl ? (audioEl.id || "") : "";
 
   // subscription links are optional
   var subscriptionLinks = {};

--- a/public/js/actions/AtomActions/getAudioPageData.js
+++ b/public/js/actions/AtomActions/getAudioPageData.js
@@ -72,7 +72,7 @@ function extractFields (audioPage) {
     contentId,
     trackUrl,
     duration: durationSeconds,
-    kicker: seriesTag.webTitle,
+    kicker: seriesTag ? seriesTag.webTitle : "",
     coverUrl: storyImage,
     subscriptionLinks
   };


### PR DESCRIPTION
First, a confession: this is the first time I've looked at this repo, and I haven't yet got a locally-running setup, so this is a bit of a shot in the dark right now.

Heres the [trello card](https://trello.com/c/eesRQZ93/706-importing-audio-episodes-bugs-in-atom-workshop).

I've looked for obvious potential problems with the handling of imported data, and added some minor defensive checks where it looked like we may be exposed.

Opening up for comments etc. while I try to find a way to test it...
