### PR TITLE
An atom is too big somewhere. Reducing page size temporarily.

### DIFF
--- a/public/js/constants/queryParams.js
+++ b/public/js/constants/queryParams.js
@@ -1,6 +1,6 @@
 export const searchParams = {
   types:[],
-  "page-size": "20",
+  "page-size": "10",
   q: "",
   searchFields: "data.title,data.label,title,labels,data.body"
 };


### PR DESCRIPTION
Atom workshop is failing with a 502 gateway error, we think because the return payload is too large due to an overweight atom somewhere.

We've tested that a page size of 10 works, so we're dropping to that until we've figured out a better fix.
