### PR TITLE
Ensure nvm is installed so that the correct node version is used

### DIFF
--- a/scripts/client-dev.sh
+++ b/scripts/client-dev.sh
@@ -9,6 +9,20 @@ do
     fi
 done
 
+fileExists() {
+  test -e "$1"
+}
+
+if ! fileExists "$NVM_DIR/nvm.sh"; then
+  node_version=`cat .nvmrc`
+  echo -e "${red}nvm not found ${plain} NVM is required to run this project"
+  echo -e "Install it from https://github.com/creationix/nvm#installation"
+  exit 1
+else
+  source "$NVM_DIR/nvm.sh"
+  nvm install
+fi
+
 export JS_ASSET_HOST="https://atomworkshop-assets.local.dev-gutools.co.uk/assets/"
 
 if [ "$IS_DEBUG" = true ] ; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,6 +5,20 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR=${DIR}/..
 
+fileExists() {
+  test -e "$1"
+}
+
+if ! fileExists "$NVM_DIR/nvm.sh"; then
+  node_version=`cat .nvmrc`
+  echo -e "${red}nvm not found ${plain} NVM is required to run this project"
+  echo -e "Install it from https://github.com/creationix/nvm#installation"
+  exit 1
+else
+  source "$NVM_DIR/nvm.sh"
+  nvm install
+fi
+
 brew bundle --file=${ROOT_DIR}/Brewfile
 
 dev-nginx setup-app ${ROOT_DIR}/nginx/nginx-mapping.yml

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,3 +1,18 @@
 #!/usr/bin/env bash
+
+fileExists() {
+  test -e "$1"
+}
+
+if ! fileExists "$NVM_DIR/nvm.sh"; then
+  node_version=`cat .nvmrc`
+  echo -e "${red}nvm not found ${plain} NVM is required to run this project"
+  echo -e "Install it from https://github.com/creationix/nvm#installation"
+  exit 1
+else
+  source "$NVM_DIR/nvm.sh"
+  nvm install
+fi
+
 yarn build-dev &
 sbt "run 9050"


### PR DESCRIPTION
I was tripped up running the setup script, without this change I had to run `source ~/.bashrc` then `nvm use` before the script would work!

Here we set the node version from .`nvmrc` if nvm is installed, and install nvm if not.