### PR TITLE
CHARTS: Get new chart atom after saving in iframe

### DIFF
--- a/public/js/components/AtomEdit/AtomEdit.js
+++ b/public/js/components/AtomEdit/AtomEdit.js
@@ -14,6 +14,7 @@ import {subscribeToPresence, enterPresence} from '../../services/presence';
 import AtomEditHeader from './AtomEditHeader';
 import {atomPropType} from '../../constants/atomPropType';
 import {logError} from '../../util/logger';
+import AtomsApi from '../../services/AtomsApi';
 
 class AtomEdit extends React.Component {
 
@@ -53,6 +54,13 @@ class AtomEdit extends React.Component {
     }
   }
 
+  updateChartAtom = () => {
+    return AtomsApi.getAtom(this.props.routeParams.atomType, this.props.routeParams.id)
+    .then(res => res.json()).then(atom => {
+      this.props.atomActions.updateAtom(atom);
+    });
+  }
+
   updateFormErrors = (errors) => {
     this.props.formErrorActions.updateFormErrors(errors);
   }
@@ -80,7 +88,7 @@ class AtomEdit extends React.Component {
       case ("commonsdivision"):
         return <CommonsDivisionEditor atom={this.props.atom} onUpdate={this.updateAtom} onFormErrorsUpdate={this.updateFormErrors} />;
        case ("chart"):
-        return <ChartEditor atom={this.props.atom} config={this.props.config} />;
+        return <ChartEditor atom={this.props.atom} config={this.props.config} onUpdate={this.updateChartAtom} />;
       case ("audio") :
         return <AudioEditor atom={this.props.atom} onUpdate={this.updateAtom} onFormErrorsUpdate={this.updateFormErrors} />;
       default:

--- a/public/js/components/AtomEdit/CustomEditors/ChartEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/ChartEditor.js
@@ -10,7 +10,8 @@ export class ChartEditor extends React.Component {
     config: PropTypes.shape({
       visualsUrl: PropTypes.string.isRequired,
       stage: PropTypes.string.isRequired
-    }).isRequired
+    }).isRequired,
+    onUpdate: PropTypes.func.isRequired
   }
 
   state = {
@@ -29,6 +30,7 @@ export class ChartEditor extends React.Component {
   closeModal = () => {
     this.setState({ modalOpen: false });
     window.removeEventListener('message', this.onMessage, false);
+    this.props.onUpdate();
   };
 
   openModal = () => {

--- a/public/js/components/Header/EditHeader.js
+++ b/public/js/components/Header/EditHeader.js
@@ -16,7 +16,7 @@ class EditHeader extends React.Component {
     atom: atomPropType,
     presence: PropTypes.bool,
     saveState: PropTypes.object,
-    formErrors: PropTypes.object,
+    formErrors: PropTypes.array,
     atomActions: PropTypes.shape({
       publishAtom: PropTypes.func.isRequired,
       takeDownAtom: PropTypes.func.isRequired,


### PR DESCRIPTION
Currently the atom doesn't refresh after you close the Charts Editor iframe. 

This makes it look like the change hasn't been saved. Actually the changed atom has been saved to CAPI but just hasn't been updated on the page. 

The fix:
This fires off an "onChartUpdate" method that hits CAPI for the latest version of the Charts Atom whenever the modal (iframe containing the charts tool editor) is closed 

