### PR TITLE
UI CLEAN-UP: Move experimental atoms further down the page

### DIFF
--- a/public/js/components/AtomCreate/AtomCreateTypeSelect.js
+++ b/public/js/components/AtomCreate/AtomCreateTypeSelect.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Link} from 'react-router';
 
-import {getNonEditableAtomTypes, snippetAtomTypes, editableNonSnippetAtomTypes} from '../../constants/atomData';
+import {getNonEditableAtomTypes, snippetAtomTypes, editableNonSnippetAtomTypes, experimentalAtomTypes} from '../../constants/atomData';
 import {AtomTypeCard} from '../AtomTypeCard/AtomTypeCard';
 
 
@@ -42,6 +42,13 @@ export class AtomCreateTypeSelect extends React.Component {
         </div>
         <div className="create__cards">
           {getNonEditableAtomTypes().map(this.renderAtomType)}
+        </div>
+        <h1 className="page__subheading">Experimental atoms</h1>
+        <div className="create__note">
+          These atoms are not supported so will not display correctly. Use only for testing purposes. 
+        </div>
+        <div className="create__cards">
+          {experimentalAtomTypes.map(this.renderAtomType)}
         </div>
       </div>
     );

--- a/public/js/constants/atomData.js
+++ b/public/js/constants/atomData.js
@@ -83,7 +83,7 @@ export const commonsDivision = {
 export const chart = {
   type: 'chart',
   fullName: 'Chart',
-  description: 'A variety of different charts',
+  description: 'A simple chart of type: bar',
 };
 
 export const audio = {
@@ -93,7 +93,6 @@ export const audio = {
 };
 
 export const allAtomTypes = [
-  cta,
   recipe,
   qa,
   guide,
@@ -101,13 +100,13 @@ export const allAtomTypes = [
   timeline,
   media,
   chart,
+  cta,
   audio,
   quiz,
   explainer,
   commonsDivision,
 ];
 export const workshopEditableAtomTypes = [
-  cta,
   recipe,
   qa,
   guide,
@@ -116,11 +115,13 @@ export const workshopEditableAtomTypes = [
   explainer,
   commonsDivision,
   chart,
+  cta,
   audio,
 ];
 
 export const snippetAtomTypes = [qa, guide, profile, timeline];
 export const legacyAtomTypes = [explainer];
+export const experimentalAtomTypes = [commonsDivision, recipe];
 
 export function getNonEditableAtomTypes() {
   return allAtomTypes.filter(atomType => {
@@ -135,7 +136,8 @@ export const editableNonSnippetAtomTypes = workshopEditableAtomTypes.filter(
   atomType => {
     return (
       !snippetAtomTypes.includes(atomType) &&
-      !legacyAtomTypes.includes(atomType)
+      !legacyAtomTypes.includes(atomType) &&
+      !experimentalAtomTypes.includes(atomType)
     );
   }
 );


### PR DESCRIPTION
The Create new atom page is a bit cluttered with atoms that currently don't work and are hardly ever / never used. Basically "Commons Divisions" - made for a hackday and "Recipes". 

This PR breaks them out into a new category "Experimental atoms". 

I've also rearranged the order a bit to bump Charts up the list above Audio. 

*** This uses the updating work in https://github.com/guardian/atom-workshop/pull/261 so has to be merged after that ***

BEFORE 
![Screenshot 2019-12-06 at 16 27 46](https://user-images.githubusercontent.com/10324129/70339303-87012d00-1846-11ea-8568-d2a984bbf364.png)

AFTER 
![Screenshot 2019-12-06 at 16 26 07](https://user-images.githubusercontent.com/10324129/70339329-908a9500-1846-11ea-9149-da471617cada.png)

