### PR TITLE
Update link to chart tool

### DIFF
--- a/public/js/components/AtomEdit/CustomEditors/ChartEditor.js
+++ b/public/js/components/AtomEdit/CustomEditors/ChartEditor.js
@@ -68,7 +68,7 @@ export class ChartEditor extends React.Component {
       __html: this.props.atom.defaultHtml
     };
 
-    const iFrameSrc = (this.props.config.stage === "PROD") ? `${this.props.config.visualsUrl}/basichartool`: `${this.props.config.visualsUrl}`;
+    const iFrameSrc = `${this.props.config.visualsUrl}/`;
 
     return (
       <div>


### PR DESCRIPTION
The charts tool has migrated away from its old home to a new domain. The `/basichartool` path, previously needed to access the tool on the Visuals server, is no longer needed.