### PR TITLE
Bump version of content-api-client and atom-maker

### DIFF
--- a/app/util/AtomElementBuilders.scala
+++ b/app/util/AtomElementBuilders.scala
@@ -47,7 +47,7 @@ object AtomElementBuilders {
       AtomType.Cta -> AtomData.Cta(CTAAtom("-")),
       AtomType.Recipe -> AtomData.Recipe(RecipeAtom(title, RecipeTags(), RecipeTime())),
       AtomType.Explainer -> AtomData.Explainer(ExplainerAtom(title, "-", DisplayType.Flat)),
-      AtomType.Qanda -> AtomData.Qanda(QAndAAtom(Some("Q&A"), None, QAndAItem(None, "Body"), None)),
+      AtomType.Qanda -> AtomData.Qanda(QAndAAtom(Some("Q&A"), None, QAndAItem(None, "Body"))),
       AtomType.Guide -> AtomData.Guide(GuideAtom(None, None, Nil)),
       AtomType.Profile -> AtomData.Profile(ProfileAtom(None, None, Nil, None)),
       AtomType.Timeline -> AtomData.Timeline(TimelineAtom()),

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.0"
 scalaVersion := "2.11.12"
 
 lazy val awsVersion = "1.11.8"
-lazy val atomLibVersion = "1.2.0"
+lazy val atomLibVersion = "1.2.3"
 
 libraryDependencies ++= Seq(
   ws,

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
   "io.circe"                 %% "circe-parser"                 % "0.11.0",
   "net.logstash.logback"     %  "logstash-logback-encoder"     % "4.2",
   "com.gu"                   %% "content-api-client-aws"       % "0.5",
-  "com.gu"                   %% "content-api-client"           % "15.4"
+  "com.gu"                   %% "content-api-client"           % "15.9"
 )
 
 resolvers ++= Seq(


### PR DESCRIPTION
Version 15.9 of content-api-cilent pulls in the updated content-atom version with all new chartType values