### PR TITLE
TAG SEARCH BUG: amend capi search to get better results

### DIFF
--- a/public/js/components/FormFields/FormFieldTagPicker.js
+++ b/public/js/components/FormFields/FormFieldTagPicker.js
@@ -14,7 +14,6 @@ export default class FormFieldTagPicker extends React.Component {
     fieldErrors: PropTypes.arrayOf(errorPropType),
     formRowClass: PropTypes.string,
     onUpdateField: PropTypes.func,
-    tagType: PropTypes.string
   };
 
   state = {
@@ -44,7 +43,7 @@ export default class FormFieldTagPicker extends React.Component {
         searchText: searchText
       });
     
-      searchTags(searchText, this.props.tagType).then((results) => {
+      searchTags(searchText).then((results) => {
         this.setState({
           suggestions: results
         });

--- a/public/js/services/capi.js
+++ b/public/js/services/capi.js
@@ -1,11 +1,9 @@
 import { pandaFetch } from './pandaFetch';
 import { uriEncodeParams, sanitiseQuery } from '../util/uriEncodeParams';
 
-export const searchTags = (searchText, type = null) => {
+export const searchTags = (searchText) => {
   return pandaFetch(
-    `/support/capi/tags?page-size=100&internal-name=${searchText}${
-      type ? `&type=${type}` : ''
-    }`,
+    `/support/capi/tags?web-title=${searchText}&page-size=100`,
     {
       method: 'get',
       credentials: 'same-origin',


### PR DESCRIPTION
The tag search results from CAPI were making it hard to add basic tags like "Football" as results were sorted alphabetically pushing common words very far down the results list. 

This fix copies the CAPI query that we use in Media-Atom-Maker for tags. It appears to add more relevant results first, by looking at "web-title" instead of "internal-name". 

All tags were requested - not just keywords so have removed the "type" check. 

![Screenshot 2020-02-13 at 12 44 56](https://user-images.githubusercontent.com/10324129/74464098-dd17cf80-4e8a-11ea-8178-508c37bcba84.png)
Too many results for Football pushed the keyword "Football" out of reach
