### PR TITLE
Chart atoms: enable all display settings by default

### DIFF
--- a/app/util/AtomElementBuilders.scala
+++ b/app/util/AtomElementBuilders.scala
@@ -56,7 +56,7 @@ object AtomElementBuilders {
         chartType = ChartType.Bar,
         furniture = Furniture(headline = "headline", source = "source"),
         tabularData = TabularData(RowType.String),
-        displaySettings = DisplaySettings(true, true)
+        displaySettings = DisplaySettings(true, true, Some(true), Some(true))
       )),
       AtomType.Audio -> AtomData.Audio(AudioAtom(
         kicker = title,


### PR DESCRIPTION
**What does this change?**
When creating a chart atom, enable all display settings by default. This will display the headline, standfirst, legend, and source as part of the chart. The user can then toggle these off if they prefer. This mirrors the behaviour of the charts tool when used independently of atom workshop.

**Why?**
This eliminates some confusion that may arise if a user tries to change the colours on a chart that has more than one data series, e.g. a stacked bar chart, where colours can only be dropped onto the legend rather than the series themselves.

![Screenshot 2020-03-24 at 10 11 33](https://user-images.githubusercontent.com/12645938/77413816-e2d0d100-6db7-11ea-8222-3b94d4d44d05.png)

**How can I test it?**
Create any type of chart atom. When you reach section 4, titled "Edit your graph", you should see all four display options are enabled, with the relevant text visible on the chart.