### PR TITLE
Allow for bigger atoms to be saved 

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -6,5 +6,7 @@ play.crypto.secret="Replace me, please!"
 
 panda.system="atom-workshop"
 
+parsers.text.maxLength=200kB
+
 // No stage-specific config should go here!
 // DEV config goes in ~/.gu/.configuration-magic/atom-workshop.conf and CODE/PROD config lives in dynamo


### PR DESCRIPTION
Some chart atoms were failing to save because the amount of data used in them (eg datasets of 1000+ lines) was too big. PUT requests to save the atom were failing with a `413 Error: Request Entity Too Large`.

## What has changed
This PR increases the size of requests accepted by the Play app - up from the default `100kB` to `200kB`.

The test dataset that was failing - the discrete line in [this spreadsheet](https://docs.google.com/spreadsheets/d/1vo8hoJi1L5BFnyooCY3pDen3mueUPGGHTBG_IGiuYrk/edit#gid=578895185), had a body size that was `104kB` large. 

See documentation for this property here: https://www.playframework.com/documentation/2.0.x/ScalaBodyParsers#Max-content-length

## To Test
Try making a discrete line chart using the data the discrete line in [this spreadsheet](https://docs.google.com/spreadsheets/d/1vo8hoJi1L5BFnyooCY3pDen3mueUPGGHTBG_IGiuYrk/edit#gid=578895185)
