### PR TITLE
improve accessibility of atom selection drop down

### DIFF
--- a/public/js/components/FormFields/SearchFields/SearchCheckboxGroup.js
+++ b/public/js/components/FormFields/SearchFields/SearchCheckboxGroup.js
@@ -48,10 +48,10 @@ export default class SearchCheckboxGroup extends React.Component {
     };
 
     return (
-      <div className="atom-search__dropdown__item" key={i}>
+      <label className="atom-search__dropdown__item" key={i}>
         <input className="atom-search__dropdown__checkbox" type="checkbox" checked={this.isChecked(fieldName)} name={fieldName} value={this.isChecked(fieldName)} onChange={updateFn} />
-        <span className="atom-search__dropdown__checkbox-label">{displayName}</span>
-      </div>
+        {displayName}
+      </label>
     );
   }
 

--- a/public/styles/components/_atom-search.scss
+++ b/public/styles/components/_atom-search.scss
@@ -84,6 +84,10 @@
       &:not(:last-child) {
         border-bottom: 1px solid $color300Grey;
       }
+
+      &:hover {
+        background: $color300Grey;
+      }
     }
 
     &--select {

--- a/public/styles/components/_atom-search.scss
+++ b/public/styles/components/_atom-search.scss
@@ -77,6 +77,7 @@
     }
 
     &__item {
+      display: block;
       background: transparent;
       padding: 10px;
 


### PR DESCRIPTION
Use a `label` for more semantic markup and to provide a larger target area for the form field and add a hover state.

# Before
![before](https://user-images.githubusercontent.com/836140/81976714-e0a12b00-9620-11ea-8032-ede75b644fe7.gif)


# After
![after](https://user-images.githubusercontent.com/836140/81976727-e39c1b80-9620-11ea-9cc6-10daeba38330.gif)
