### PR TITLE
Display full name on hover over Presence indicator

### DIFF
--- a/public/js/components/Utilities/PresenceIndicator.js
+++ b/public/js/components/Utilities/PresenceIndicator.js
@@ -13,7 +13,7 @@ export default class PresenceIndicator extends React.Component {
   renderPresenceUser = (state) => {
     const user = state.clientId.person;
     return (
-      <li key="state.clientId.connId" className="presence-list__user">{this.getInitials(user.firstName, user.lastName)}</li>
+      <li key="state.clientId.connId" className="presence-list__user" title={user.firstName + " " + user.lastName}>{this.getInitials(user.firstName, user.lastName)}</li>
     );
   };
 


### PR DESCRIPTION
## What does this change?
The Presence indicator in Atom Workshop displays users initials. This PR adds a title to the indicator, displaying the users full name on hover (to mirror the behaviour of the indicator in Workflow). 

![](https://github.trello.services/images/mini-trello-icon.png) [Presence icon doesn't display in Workflow for Chart atoms](https://trello.com/c/qdoGcT4H/1994-presence-icon-doesnt-display-in-workflow-for-chart-atoms)

## How to test

- If testing locally, you will need to [enable and run Presence locally](https://github.com/guardian/presence-indicator). This will include setting the `presence.enabled` value to true and `presence.domain` to `"presence.local.dev-gutools.co.uk"` in Atom Workshop's config. After you've enabled and run Presence, [create a Chart atom](https://atomworkshop.local.dev-gutools.co.uk/create/chart) and after saving, observe the Presence indicator is there and that on hover, your full name is displayed.
- If testing on CODE, deploy this branch, [create a Chart atom](https://atomworkshop.code.dev-gutools.co.uk/create/chart) and after saving, observe the Presence indicator is there and that on hover, your full name is displayed.

## Images
![Screenshot 2020-07-31 at 14 42 05](https://user-images.githubusercontent.com/12645938/89040688-11e5e900-d33c-11ea-8426-b0f8781c63f5.png)

