### PR TITLE
Switch from provisioned to on-demand billing for dynamo tables

### DIFF
--- a/cloudformation/DynamoTables.yml
+++ b/cloudformation/DynamoTables.yml
@@ -1,17 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
-  PreviewReadCapacity:
-    Type: String
-    Description: Read Capacity of the PROD table
-  PreviewWriteCapacity:
-    Type: String
-    Description: Write Capacity of the PROD table
-  LiveReadCapacity:
-    Type: String
-    Description: Read Capacity of the PROD table
-  LiveWriteCapacity:
-    Type: String
-    Description: Write Capacity of the PROD table
   Stage:
     Type: String
     Description: Stage for the tables
@@ -34,9 +22,7 @@ Resources:
           KeyType: "HASH"
         - AttributeName: "id"
           KeyType: "RANGE"
-      ProvisionedThroughput:
-        ReadCapacityUnits: !Ref PreviewReadCapacity
-        WriteCapacityUnits: !Ref PreviewWriteCapacity
+      BillingMode: "PAY_PER_REQUEST"
   AtomWorkshopLiveDynamoTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -51,9 +37,7 @@ Resources:
           KeyType: "HASH"
         - AttributeName: "id"
           KeyType: "RANGE"
-      ProvisionedThroughput:
-        ReadCapacityUnits: !Ref LiveReadCapacity
-        WriteCapacityUnits: !Ref LiveWriteCapacity
+      BillingMode: "PAY_PER_REQUEST"
 Outputs:
   PreviewDynamoTableOut:
     Description: Table name for Preview dynamo table


### PR DESCRIPTION
## What does this change?
While querying the the atom-workshop live and preview tables, @akash1810 and I observed the tables had a relatively low read/write capacity and frequently exceeded their provisioned read throughput. 

## How to test
Observe Atom Workshop DynamoDB metrics.

## How can we measure success?
Tables do not exceed read/write capacity.

## Have we considered potential risks?
Recent investigations within the department have identified a relatively small difference between the cost of using provisioned vs. on-demand resources, so it seems reasonable to make this change.

## Images
n/a
