### PR TITLE
upgrade AWS SDK to min. version required for IMDSv2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ version := "1.0"
 
 scalaVersion := "2.11.12"
 
-lazy val awsVersion = "1.11.8"
+lazy val awsVersion = "1.11.678"
 lazy val atomLibVersion = "1.2.3"
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
_This is a pre-requisite for https://github.com/guardian/editorial-tools-platform/pull/534_

Upgrade AWS SDK to min. version required for IMDSv2 to address https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#ec2-8-remediation as per https://github.com/guardian/security-hq/blob/main/hq/markdown/guardduty-sechub-common-problems.md#ec2-instances-should-use-imdsv2

**✅  Tested in `CODE`**, the below graph shows drop-off in usage of IMDSv1 for the relevant ASG...
![image](https://user-images.githubusercontent.com/19289579/115280240-9f25d380-a13f-11eb-9ea8-c46dc90155a4.png)

