### PR TITLE
Remove reference to bintray

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 logLevel := Level.Warn
 
-resolvers += "Typesafe repository" at "https://dl.bintray.com/typesafe/maven-releases/"
-
 libraryDependencies += "org.vafer" % "jdeb" % "1.6" artifacts (Artifact("jdeb", "jar", "jar"))
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")


### PR DESCRIPTION
## What does this change?

Removes a reference to Bintray as a resolver. The application builds fine without it when using [these instructions](https://docs.google.com/document/d/1oWJs5I1TnCQkoiswMLRI6zaU1nvRXw1onVvoktsY43U/edit#) to prevent resolving it correctly.

## How to test

Follow the instructions above to prevent Bintray from resolving locally, and build the project. Is it successful?

