### PR TITLE
upgrading sbt

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18


### PR DESCRIPTION
This build was failing to build on my machine with a:

```
[info] Compiling 1 Scala source to /Users/francis_rhys-jones/code/crossword-status-checker/project/target/scala-2.10/sbt-0.13/classes...
sbt.InvalidComponent: Could not find required component 'xsbti'
```

There are various confusing bug report and workarounds:

https://github.com/sbt/sbt/issues/6447

Upgrading the version of sbt seemed to work for me. 

Upgrading any further would require some more indepth upgrading of the plugin dependencies so Ive left it at the latest 0.13.x release.
