### PR TITLE
fixes the isHttpsUrl regex

### DIFF
--- a/public/js/util/validators.js
+++ b/public/js/util/validators.js
@@ -8,14 +8,21 @@ import FieldError from '../constants/FieldError';
 
 export const isHttpsUrl = value => {
   const stringValue = typeof value === 'string' ? value : '';
-  if (
-    stringValue.match(
-      /^(https:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/
-    )
-  ) {
+
+  try {
+
+    const url = new URL(stringValue);
+
+    if (url.protocol !== "https:") {
+      const error = new FieldError('not-https', 'Not a HTTPS url');
+      return Promise.resolve(error);
+    }
+
     return Promise.resolve(true);
-  } else {
-    const error = new FieldError('not-https', 'Not a HTTPS url');
+
+  }
+  catch (e) {
+    const error = new FieldError('not-url', 'Not a valid url');
     return Promise.resolve(error);
   }
 };

--- a/public/js/util/validators.spec.js
+++ b/public/js/util/validators.spec.js
@@ -1,19 +1,42 @@
-import {isHttpsUrl} from './validators';
+import { isHttpsUrl } from './validators';
 
-test('Should validate as HTTPS URL', () => {
-  let url = 'https://example.com';
 
-  return isHttpsUrl(url)
-    .then(res => {
-       expect(res).toBe(true);
-    });
-});
+describe("isHttpsUrl function", () => {
 
-test('Should return an error', () => {
-  let url = 'wrong';
+  it('Should validate a simple URL as an HTTPS URL', () => {
+    let url = 'https://example.com';
 
-  return isHttpsUrl(url)
-    .then(res => {
-      expect(res.title).toBe('not-https');
-    });
+    isHttpsUrl(url)
+      .then(res => {
+        expect(res).toBe(true);
+      });
+  });
+
+  it('Should validate a complex URL as an HTTPS URL', () => {
+    let url = 'https://example.co.uk/broken/test(1).mp3';
+
+    isHttpsUrl(url)
+      .then(res => {
+        expect(res).toBe(true);
+      });
+  });
+
+  it('Should reject an invalid URL', () => {
+    let url = 'wrong';
+
+    isHttpsUrl(url)
+      .then(res => {
+        expect(res.title).toBe('not-url');
+      });
+  });
+
+  it('Should reject an HTTP URL', () => {
+    let url = 'http://example.com';
+
+    isHttpsUrl(url)
+      .then(res => {
+        expect(res.title).toBe('not-https');
+      });
+  });
+
 });


### PR DESCRIPTION
## What does this change?

This PR fixes an issue which causes validating URLs containing brackets to crash the site.

The validation function `isHttpsUrl` contained a `regex` that would blow up if it detected a string with brackets in the wrong place. [Regex 101](https://regex101.com/) would detect this as **catastrophic backtracking**.

For example this string would cause issues: https://example.co.uk/broken/test(1).mp3

~~To fix this issue I've removed the extra `*` as it seems to be redundant and included brackets in the acceptable character set.~~

I have replaced the regex with a check using the URL class.

## How to test

Are we able to add media atoms where the Track URL contains brackets? We can test this locally or on CODE.

## How can we measure success?

Users are able to successfully add track URLs with brackets.

## Have we considered potential risks?

Working with regex...
