### PR TITLE
Adds GitHub action CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - master
-env:
-  FINAL_TEAMCITY_BUILD: 1309
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -46,5 +44,6 @@ jobs:
     - name: CI for sbt-riffraff-artifact
       shell: bash
       run: |
-        export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + env.FINAL_TEAMCITY_BUILD ))
-        sbt clean compile
+        FINAL_TEAMCITY_BUILD=1319
+        export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $FINAL_TEAMCITY_BUILD ))
+        sbt clean compile riffRaffUpload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ jobs:
       with:
         java-version: 8
         distribution: adopt
+    - name: Cache SBT
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.ivy2/cache
+          ~/.sbt
+        key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
     - name: CI yarn
       shell: bash
       run: | 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - $default-branch
+      - master
 env:
   FINAL_TEAMCITY_BUILD: 1309
 jobs:
@@ -23,11 +23,7 @@ jobs:
     - uses: guardian/actions-assume-aws-role@v1
       with:
         awsRoleToAssume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-    - name: Get node version
-      run: echo NODE_VERSION=$(cat .nvmrc) >> $GITHUB_ENV
-    - uses: actions/setup-node@v2
-      with:
-          node-version: ${{ env.NODE_VERSION }}
+    - uses: guardian/actions-setup-node@v2.4.1
     - name: Set up JDK
       uses: actions/setup-java@v2
       with:
@@ -43,5 +39,5 @@ jobs:
     - name: CI for sbt-riffraff-artifact
       shell: bash
       run: |
-        export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $FINAL_TEAMCITY_BUILD ))
+        export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + env.FINAL_TEAMCITY_BUILD ))
         sbt clean compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI for sbt-riffraff-artifact
+
+on:
+  pull_request:
+  # Manual invocation.
+  workflow_dispatch:
+  push:
+    branches:
+      - $default-branch
+env:
+  FINAL_TEAMCITY_BUILD: 1309
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+    permissions:
+      # required by guardian/actions-assume-aws-role
+      id-token: write
+      contents: read
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v2
+    - uses: guardian/actions-assume-aws-role@v1
+      with:
+        awsRoleToAssume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+    - name: Get node version
+      run: echo NODE_VERSION=$(cat .nvmrc) >> $GITHUB_ENV
+    - uses: actions/setup-node@v2
+      with:
+          node-version: ${{ env.NODE_VERSION }}
+    - name: Set up JDK
+      uses: actions/setup-java@v2
+      with:
+        java-version: 8
+        distribution: adopt
+    - name: CI yarn
+      shell: bash
+      run: | 
+        yarn install --force --frozen-lockfile
+        yarn lint
+        yarn test
+        yarn build
+    - name: CI for sbt-riffraff-artifact
+      shell: bash
+      run: |
+        export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $FINAL_TEAMCITY_BUILD ))
+        sbt clean compile

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ libraryDependencies += "org.vafer" % "jdeb" % "1.6" artifacts (Artifact("jdeb", 
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.17")
 
  addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")


### PR DESCRIPTION
## What does this change?

This PR attempts to move our CI away from TeamCity and into GitHub actions using the [latest tools from DevX](https://docs.google.com/document/d/1Xz-gzptICIza0oio0Kza3LWg2a6n_015o0MPu0LGfuU/edit#).

**NB** The action will run for the PR but will not attempt to upload until we add `riffRaffUpload` to the sbt step.

## How to test

We will need to pause TC build and set the build number, we should then be able to test the process end-to-end using CODE.

## How can we measure success?

We move away from TeamCity builds and gain all the benefits of GitHub actions!

## Have we considered potential risks?

This could be disruptive for Atom Workshop builds.