### PR TITLE
Passes logging timestamp transparently

### DIFF
--- a/fluentbit/parsers.conf
+++ b/fluentbit/parsers.conf
@@ -2,5 +2,3 @@
 [PARSER]
   Name systemd_json
   Format json
-  Time_Key @timestamp
-  Time_Format %Y-%m-%dT%H:%M:%S.%L%z

--- a/fluentbit/td-agent-bit.conf
+++ b/fluentbit/td-agent-bit.conf
@@ -64,5 +64,3 @@
   region eu-west-1
   # To be replaced with the actual value by the CFN
   stream STACK_STREAM
-  time_key @timestamp
-  time_key_format %Y-%m-%dT%H:%M:%S.%L%z


### PR DESCRIPTION
## What does this change?

This PR aims to fix issues with the timestamp in the ELK logs:  

before:
![image](https://user-images.githubusercontent.com/4633246/141984699-86b4d78b-1987-433c-87fb-3450a6664ee6.png)

after: 
![image](https://user-images.githubusercontent.com/4633246/141986606-b9827c82-a2aa-456d-a288-3f091ce5080e.png)

The change fixes this issue by no longer parsing the time from the log JSON, and then parsing it back out as a key. Instead we simply pass the keys straight through to Fluent Bit.


## How to test

Deploy to CODE via riff-raff, observe the logs. 
The timestamp in ELK should match the JSON output on the box. This can be retrieved by SSHing onto the box and running: `journalctl -u atom-workshop.service`

## Note 

We aren't currently parsing the time format from non-JSON log-lines, meaning we can see the keyed timestamp doesn't match the message. We could fix this by creating a custom parser for the format, or changing how they're encoded. As these we're logs we didn't previously include, I'm not treating this issue as a priority: 
![image](https://user-images.githubusercontent.com/4633246/141987295-984203a0-1739-4caf-b979-346f332ad0c7.png)
