### PR TITLE
Play 2.6 upgrade

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -20,10 +20,10 @@ class AppComponents(context: Context)
   lazy val router = new Routes(httpErrorHandler, appController, healthcheckController, loginController, assets, supportController, reindex, explainerReindex)
   lazy val appController = new controllers.App(wsClient, atomWorkshopDB, permissions, controllerComponents)
   lazy val loginController = new controllers.Login(wsClient, controllerComponents)
-  lazy val healthcheckController = new controllers.Healthcheck()
+  lazy val healthcheckController = new controllers.Healthcheck(controllerComponents)
   lazy val supportController = new controllers.Support(wsClient, controllerComponents)
 
-  lazy val reindex = new ReindexController(previewDataStore, publishedDataStore, reindexPreview, reindexPublished, Configuration(config), actorSystem)
+  lazy val reindex = new ReindexController(previewDataStore, publishedDataStore, reindexPreview, reindexPublished, Configuration(config), controllerComponents, actorSystem)
 
   lazy val explainerReindex = new ExplainerReindexController(
     wsClient,

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,24 +1,27 @@
 import com.gu.atom.play.ReindexController
-import config.Config.{config, permissions, dynamoDB, capiDynamoDB, capiLambdaClient}
+import com.typesafe.config.Config
+import config.Config.{capiDynamoDB, capiLambdaClient, config, dynamoDB, permissions}
 import controllers.ExplainerReindexController
 import db.AtomDataStores._
 import db.AtomWorkshopDB
 import db.ExplainerDB
 import db.ReindexDataStores._
+import play.api.Configuration
 import play.api.ApplicationLoader.Context
-import play.api._
+import play.api.BuiltInComponentsFromContext
 import play.api.libs.ws.ahc.AhcWSComponents
+import controllers.AssetsComponents
+import play.filters.HttpFiltersComponents
 import router.Routes
 
 class AppComponents(context: Context)
-  extends BuiltInComponentsFromContext(context) with AhcWSComponents {
+  extends BuiltInComponentsFromContext(context) with AhcWSComponents with AssetsComponents with HttpFiltersComponents {
 
   lazy val router = new Routes(httpErrorHandler, appController, healthcheckController, loginController, assets, supportController, reindex, explainerReindex)
-  lazy val assets = new controllers.Assets(httpErrorHandler)
-  lazy val appController = new controllers.App(wsClient, atomWorkshopDB, permissions)
-  lazy val loginController = new controllers.Login(wsClient)
+  lazy val appController = new controllers.App(wsClient, atomWorkshopDB, permissions, controllerComponents)
+  lazy val loginController = new controllers.Login(wsClient, controllerComponents)
   lazy val healthcheckController = new controllers.Healthcheck()
-  lazy val supportController = new controllers.Support(wsClient)
+  lazy val supportController = new controllers.Support(wsClient, controllerComponents)
 
   lazy val reindex = new ReindexController(previewDataStore, publishedDataStore, reindexPreview, reindexPublished, Configuration(config), actorSystem)
 
@@ -29,7 +32,8 @@ class AppComponents(context: Context)
     explainerPublishedDataStore,
     reindexPreview,
     reindexPublished,
-    Configuration(config)
+    Configuration(config),
+    controllerComponents
   )(actorSystem.dispatcher)
 
   lazy val atomWorkshopDB = new AtomWorkshopDB()

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -17,7 +17,9 @@ import router.Routes
 class AppComponents(context: Context)
   extends BuiltInComponentsFromContext(context) with AhcWSComponents with AssetsComponents with HttpFiltersComponents {
 
-  lazy val router = new Routes(httpErrorHandler, appController, healthcheckController, loginController, assets, supportController, reindex, explainerReindex)
+  override lazy val router = new Routes(httpErrorHandler, appController, healthcheckController, loginController, assets, supportController, reindex, explainerReindex)
+  override lazy val httpFilters = super.httpFilters.filterNot(_ == allowedHostsFilter)
+
   lazy val appController = new controllers.App(wsClient, atomWorkshopDB, permissions, controllerComponents)
   lazy val loginController = new controllers.Login(wsClient, controllerComponents)
   lazy val healthcheckController = new controllers.Healthcheck(controllerComponents)

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -98,16 +98,19 @@ object Config extends AwsInstanceTags {
 
   val capiLambdaClient = AWSLambdaClientBuilder.standard()
     .withCredentials(capiReaderQuestionsCredentials)
+    .withRegion(region.getName)
     .build()
 
   val capiDynamoDB = AmazonDynamoDBClientBuilder.standard()
     .withCredentials(capiReaderQuestionsCredentials)
+    .withRegion(region.getName)
     .build()
 
   val atomEditorGutoolsDomain = config.getString("atom.editors.gutoolsDomain")
 
   val kinesisClient = AmazonKinesisClientBuilder.standard()
     .withCredentials(awsCredentialsProvider)
+    .withRegion(region.getName)
     .build()
 
   // Not sure if we need a full config or if we can just inline the name

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -1,15 +1,10 @@
 package config
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{
-  AWSCredentialsProvider, 
-  AWSCredentialsProviderChain, 
-  InstanceProfileCredentialsProvider, 
-  STSAssumeRoleSessionCredentialsProvider
-}
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
-import com.amazonaws.services.kinesis.AmazonKinesisClient
-import com.amazonaws.services.lambda.AWSLambdaClient
+import com.amazonaws.auth.{AWSCredentialsProvider, AWSCredentialsProviderChain, InstanceProfileCredentialsProvider, STSAssumeRoleSessionCredentialsProvider}
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
+import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder
+import com.amazonaws.services.lambda.AWSLambdaClientBuilder
 import com.gu.cm.{Mode, Configuration => ConfigurationMagic}
 import services.{AtomWorkshopPermissionsProvider, AwsInstanceTags}
 
@@ -52,11 +47,11 @@ object Config extends AwsInstanceTags {
   val pandaAuthCallback = config.getString("panda.authCallback")
   val pandaSystem = config.getString("panda.system")
 
-  val dynamoDB = region.createClient(
-    classOf[AmazonDynamoDBClient],
-    awsCredentialsProvider,
-    null
-  )
+  val dynamoDB = AmazonDynamoDBClientBuilder
+    .standard()
+    .withCredentials(awsCredentialsProvider)
+    .withRegion(region.getName)
+    .build()
 
   val previewDynamoTableName = config.getString("aws.dynamo.preview.tableName")
   val publishedDynamoTableName = config.getString("aws.dynamo.live.tableName")
@@ -101,25 +96,19 @@ object Config extends AwsInstanceTags {
     )
   }
 
-  val capiLambdaClient = region.createClient(
-    classOf[AWSLambdaClient],
-    capiReaderQuestionsCredentials,
-    null
-  )
+  val capiLambdaClient = AWSLambdaClientBuilder.standard()
+    .withCredentials(capiReaderQuestionsCredentials)
+    .build()
 
-  val capiDynamoDB = region.createClient(
-    classOf[AmazonDynamoDBClient],
-    capiReaderQuestionsCredentials,
-    null
-  )
+  val capiDynamoDB = AmazonDynamoDBClientBuilder.standard()
+    .withCredentials(capiReaderQuestionsCredentials)
+    .build()
 
   val atomEditorGutoolsDomain = config.getString("atom.editors.gutoolsDomain")
 
-  val kinesisClient = region.createClient(
-    classOf[AmazonKinesisClient],
-    awsCredentialsProvider,
-    null
-  )
+  val kinesisClient = AmazonKinesisClientBuilder.standard()
+    .withCredentials(awsCredentialsProvider)
+    .build()
 
   // Not sure if we need a full config or if we can just inline the name
   // of the function here

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -20,6 +20,7 @@ import util.AtomUpdateOperations._
 import util.Parser._
 import util.CORSable
 import com.gu.pandomainauth.model.{User => PandaUser}
+import views.html.helper.CSRF
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -41,7 +42,7 @@ class App(val wsClient: WSClient, val atomWorkshopDB: AtomWorkshopDBAPI,
     }
   }
   
-  def index(placeholder: String) = AuthAction.async { req =>
+  def index(placeholder: String) = AuthAction.async { implicit req =>
     Logger.info(s"I am the ${Config.appName}")
 
     permissions.getAll(req.user.email).map { permissions =>
@@ -78,7 +79,8 @@ class App(val wsClient: WSClient, val atomWorkshopDB: AtomWorkshopDBAPI,
         "Atom Workshop",
         jsLocation,
         presenceJsFile,
-        clientConfig.asJson.noSpaces)
+        clientConfig.asJson.noSpaces,
+        Some(CSRF.getToken.value))
       )
     }
   }

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -80,8 +80,8 @@ class App(val wsClient: WSClient, val atomWorkshopDB: AtomWorkshopDBAPI,
         jsLocation,
         presenceJsFile,
         clientConfig.asJson.noSpaces,
-        Some(CSRF.getToken.value))
-      )
+        CSRF.getToken.value
+      ))
     }
   }
 

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -8,7 +8,6 @@ import com.gu.pandomainauth.action.UserRequest
 import config.Config
 import db.AtomDataStores._
 import db.AtomWorkshopDBAPI
-import play.api.libs.concurrent.Execution.Implicits._
 import models._
 import play.api.Logger
 import play.api.libs.ws.WSClient
@@ -31,7 +30,7 @@ class App(val wsClient: WSClient, val atomWorkshopDB: AtomWorkshopDBAPI,
   import io.circe._
   import io.circe.syntax._
 
-  override protected val executionContext = controllerComponents.executionContext
+  implicit val executionContext = controllerComponents.executionContext
 
   override protected val parser: BodyParser[AnyContent] = controllerComponents.parsers.defaultBodyParser
 

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -12,7 +12,7 @@ import play.api.libs.concurrent.Execution.Implicits._
 import models._
 import play.api.Logger
 import play.api.libs.ws.WSClient
-import play.api.mvc.{ActionBuilder, Controller, Request, Result}
+import play.api.mvc._
 import services.AtomPublishers._
 import services.AtomWorkshopPermissionsProvider
 import util.AtomElementBuilders
@@ -20,17 +20,20 @@ import util.AtomLogic._
 import util.AtomUpdateOperations._
 import util.Parser._
 import util.CORSable
-import play.api.mvc.Action
 import com.gu.pandomainauth.model.{User => PandaUser}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class App(val wsClient: WSClient, val atomWorkshopDB: AtomWorkshopDBAPI,
-          val permissions: AtomWorkshopPermissionsProvider) extends Controller with PanDomainAuthActions {
+          val permissions: AtomWorkshopPermissionsProvider, val controllerComponents: ControllerComponents) extends BaseController with PanDomainAuthActions {
 
   // These are required even though IntelliJ thinks they are not
   import io.circe._
   import io.circe.syntax._
+
+  override protected val executionContext = controllerComponents.executionContext
+
+  override protected val parser: BodyParser[AnyContent] = controllerComponents.parsers.defaultBodyParser
 
   def allowCORSAccess(methods: String, args: Any*) = CORSable(Config.workflowUrl, Config.visualsUrl) {
     Action { implicit req =>
@@ -181,22 +184,6 @@ class App(val wsClient: WSClient, val atomWorkshopDB: AtomWorkshopDBAPI,
         atomType <- validateAtomType(atomType)
         result <- takedown(atomType, id, req.user)
       } yield result
-    }
-  }
-
-  class PermissionedAction(permission: Permission) extends ActionBuilder[UserRequest] {
-    override def invokeBlock[A](request: Request[A], block: UserRequest[A] => Future[Result]): Future[Result] = {
-      AuthAction.invokeBlock(request, { req: UserRequest[A] =>
-
-        permissions.get(permission)(PermissionsUser(req.user.email)).flatMap {
-          case PermissionGranted =>
-            block(req)
-
-          case _ =>
-            Future.successful(Unauthorized(s"User ${req.user.email} is not authorised for permission ${permission.name}"))
-
-        }
-      })
     }
   }
 

--- a/app/controllers/ExplainerReindexController.scala
+++ b/app/controllers/ExplainerReindexController.scala
@@ -32,7 +32,7 @@ class ExplainerReindexController(
 
   // Copy-pasted from the atom-maker library
   object ApiKeyAction extends ActionBuilder[Request, AnyContent] {
-    lazy val apiKey = config.getString("reindexApiKey").get
+    lazy val apiKey = config.get[String]("reindexApiKey")
 
     def invokeBlock[A](request: Request[A], block: (Request[A] => Future[Result])) = {
       if(request.getQueryString("api").contains(apiKey))

--- a/app/controllers/ExplainerReindexController.scala
+++ b/app/controllers/ExplainerReindexController.scala
@@ -5,10 +5,10 @@ import com.gu.atom.publish.{AtomReindexer, PreviewAtomReindexer, PublishedAtomRe
 import db.ExplainerDBAPI
 import play.api.Configuration
 import play.api.libs.ws.WSClient
-import play.api.mvc.{ Action, ActionBuilder, AnyContent, Controller, Result, Request }
+import play.api.mvc.{Action, ActionBuilder, AnyContent, BaseController, BodyParser, ControllerComponents, Request, Result}
 import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 import play.api.libs.json.Json
 import play.api.Logger
 
@@ -19,14 +19,19 @@ class ExplainerReindexController(
   publishedDataStore: DynamoDataStore,
   previewReindexer: PreviewAtomReindexer,
   publishedReindexer: PublishedAtomReindexer,
-  config: Configuration
-)(implicit ec: ExecutionContext) extends Controller with PanDomainAuthActions {
+  config: Configuration,
+  val controllerComponents: ControllerComponents
+)(implicit ec: ExecutionContext) extends BaseController with PanDomainAuthActions {
 
   var lastPublished: Int = 0
   var lastPreview: Int = 0
 
+  override protected val executionContext = controllerComponents.executionContext
+
+  override protected val parser: BodyParser[AnyContent] = controllerComponents.parsers.defaultBodyParser
+
   // Copy-pasted from the atom-maker library
-  object ApiKeyAction extends ActionBuilder[Request] {
+  object ApiKeyAction extends ActionBuilder[Request, AnyContent] {
     lazy val apiKey = config.getString("reindexApiKey").get
 
     def invokeBlock[A](request: Request[A], block: (Request[A] => Future[Result])) = {
@@ -35,6 +40,10 @@ class ExplainerReindexController(
       else
         Future.successful(Unauthorized(""))
     }
+
+    override def parser: BodyParser[AnyContent] = controllerComponents.parsers.defaultBodyParser
+
+    override protected def executionContext: ExecutionContext = controllerComponents.executionContext
   }
 
   def reindex(stack: String): Action[AnyContent] = ApiKeyAction.async { req => 

--- a/app/controllers/Healthcheck.scala
+++ b/app/controllers/Healthcheck.scala
@@ -1,8 +1,8 @@
 package controllers
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{BaseController, ControllerComponents}
 
-class Healthcheck extends Controller {
+class Healthcheck(val controllerComponents: ControllerComponents) extends BaseController {
 
   def healthcheck = Action {
     Ok("Healthcheck")

--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -3,7 +3,11 @@ package controllers
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 
-class Login(val wsClient: WSClient) extends Controller with PanDomainAuthActions {
+class Login(val wsClient: WSClient, val controllerComponents: ControllerComponents) extends BaseController with PanDomainAuthActions {
+
+  override protected val executionContext = controllerComponents.executionContext
+
+  override protected val parser: BodyParser[AnyContent] = controllerComponents.parsers.defaultBodyParser
 
   def reauth = AuthAction {
     Ok("auth ok")

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -5,14 +5,13 @@ import java.net.URI
 import com.gu.contentapi.client.IAMSigner
 import config.Config
 import play.api.libs.ws.WSClient
-import play.api.mvc.{AnyContent, BaseController, BodyParser, Controller, ControllerComponents, Result}
-import play.api.libs.concurrent.Execution.Implicits._
+import play.api.mvc.{AnyContent, BaseController, BodyParser, ControllerComponents, Result}
 import play.api.Logger
 import scala.concurrent.Future
 
 class Support(val wsClient: WSClient, val controllerComponents: ControllerComponents) extends BaseController with PanDomainAuthActions {
 
-  override protected val executionContext = controllerComponents.executionContext
+  implicit val executionContext = controllerComponents.executionContext
 
   override protected val parser: BodyParser[AnyContent] = controllerComponents.parsers.defaultBodyParser
 
@@ -35,7 +34,7 @@ class Support(val wsClient: WSClient, val controllerComponents: ControllerCompon
   def query(url: String, headers: Seq[(String, String)]): Future[Result] = {
     val req = wsClient
       .url(url)
-      .withHeaders(headers: _*)
+      .withHttpHeaders(headers: _*)
       .get()
 
     req.map(response => response.status match {

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -5,12 +5,16 @@ import java.net.URI
 import com.gu.contentapi.client.IAMSigner
 import config.Config
 import play.api.libs.ws.WSClient
-import play.api.mvc.{ Controller, Result }
+import play.api.mvc.{AnyContent, BaseController, BodyParser, Controller, ControllerComponents, Result}
 import play.api.libs.concurrent.Execution.Implicits._
 import play.api.Logger
 import scala.concurrent.Future
 
-class Support(val wsClient: WSClient) extends Controller with PanDomainAuthActions {
+class Support(val wsClient: WSClient, val controllerComponents: ControllerComponents) extends BaseController with PanDomainAuthActions {
+
+  override protected val executionContext = controllerComponents.executionContext
+
+  override protected val parser: BodyParser[AnyContent] = controllerComponents.parsers.defaultBodyParser
 
   private val signer = new IAMSigner(
     credentialsProvider = Config.capiPreviewCredentials,

--- a/app/services/EC2Client.scala
+++ b/app/services/EC2Client.scala
@@ -1,7 +1,7 @@
 package services
 
 import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.ec2.AmazonEC2Client
+import com.amazonaws.services.ec2.AmazonEC2ClientBuilder
 import com.amazonaws.services.ec2.model.{DescribeTagsRequest, Filter}
 import com.amazonaws.util.EC2MetadataUtils
 
@@ -11,7 +11,9 @@ import scala.collection.JavaConversions._
 object EC2Client {
   lazy val region = Option(Regions.getCurrentRegion).getOrElse(Region.getRegion(Regions.EU_WEST_1))
 
-  lazy val EC2Client = region.createClient(classOf[AmazonEC2Client], null, null)
+  lazy val EC2Client = AmazonEC2ClientBuilder.standard()
+    .withRegion(region.getName)
+    .build()
 }
 
 trait AwsInstanceTags {

--- a/app/util/CORSable.scala
+++ b/app/util/CORSable.scala
@@ -3,7 +3,7 @@ package util
 import play.api.mvc.{Action, BodyParser, Request, Result}
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 case class CORSable[A](origins: String*)(action: Action[A]) extends Action[A] {
 
@@ -17,4 +17,6 @@ case class CORSable[A](origins: String*)(action: Action[A]) extends Action[A] {
   }
 
   lazy val parser: BodyParser[A] = action.parser
+
+  override def executionContext: ExecutionContext = action.executionContext
 }

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -3,7 +3,7 @@
         jsLocation: String,
         presenceJsLocation: Option[String],
         clientConfigJson: String,
-        csrf: Option[String] = None
+        csrf: String
 )
 <!DOCTYPE html>
 <html lang="en">
@@ -12,14 +12,12 @@
         <meta charset="UTF-8">
         <title>Atom Workshop</title>
         <link rel="stylesheet" href="@routes.Assets.versioned("build/main.css")">
-        @csrf.map { token =>
-            <script type="text/javascript">
-                    window.guardian = window.guardian || {};
-                    if(!window.guardian.csrf) {
-                        window.guardian.csrf = {token: "@token"}
-                    }
-            </script>
-        }
+        <script type="text/javascript">
+                window.guardian = window.guardian || {};
+                if(!window.guardian.csrf) {
+                    window.guardian.csrf = {token: "@csrf"}
+                }
+        </script>
     </head>
 
     <body>

--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -1,4 +1,10 @@
-@(title: String, jsLocation: String, presenceJsLocation: Option[String], clientConfigJson: String)
+@(
+        title: String,
+        jsLocation: String,
+        presenceJsLocation: Option[String],
+        clientConfigJson: String,
+        csrf: Option[String] = None
+)
 <!DOCTYPE html>
 <html lang="en">
 
@@ -6,6 +12,14 @@
         <meta charset="UTF-8">
         <title>Atom Workshop</title>
         <link rel="stylesheet" href="@routes.Assets.versioned("build/main.css")">
+        @csrf.map { token =>
+            <script type="text/javascript">
+                    window.guardian = window.guardian || {};
+                    if(!window.guardian.csrf) {
+                        window.guardian.csrf = {token: "@token"}
+                    }
+            </script>
+        }
     </head>
 
     <body>

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.0"
 scalaVersion := "2.11.12"
 
 lazy val awsVersion = "1.11.678"
-lazy val atomLibVersion = "1.2.5-SNAPSHOT"
+lazy val atomLibVersion = "1.2.5"
 
 libraryDependencies ++= Seq(
   ws,

--- a/build.sbt
+++ b/build.sbt
@@ -32,10 +32,7 @@ resolvers ++= Seq(
 
 routesGenerator := InjectedRoutesGenerator
 
-import com.typesafe.sbt.packager.archetypes.systemloader.ServerLoader.Systemd
-serverLoading in Debian := Some(Systemd)
-
-lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging)
+lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging, SystemdPlugin)
   .settings(Defaults.coreDefaultSettings: _*)
   .settings(
     name in Universal := normalizedName.value,

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "com.gu"                   %% "configuration-magic-core"     % "1.3.0",
   "com.gu"                   %% "fezziwig"                     % "1.2",
   "com.gu"                   %  "kinesis-logback-appender"     % "1.4.4",
-  "com.gu"                   %% "pan-domain-auth-play_2-5"     % "0.4.1",
+  "com.gu"                   %% "pan-domain-auth-play_2-6"     % "0.5.0",
   "io.circe"                 %% "circe-parser"                 % "0.11.0",
   "net.logstash.logback"     %  "logstash-logback-encoder"     % "6.6",
   "com.gu"                   %% "content-api-client-aws"       % "0.5",
@@ -32,8 +32,8 @@ resolvers ++= Seq(
 
 routesGenerator := InjectedRoutesGenerator
 
-import com.typesafe.sbt.packager.archetypes.ServerLoader.Systemd
-serverLoading in Debian := Systemd
+import com.typesafe.sbt.packager.archetypes.systemloader.ServerLoader.Systemd
+serverLoading in Debian := Some(Systemd)
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact, JDebPackaging)
   .settings(Defaults.coreDefaultSettings: _*)

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.0"
 scalaVersion := "2.11.12"
 
 lazy val awsVersion = "1.11.678"
-lazy val atomLibVersion = "1.2.3"
+lazy val atomLibVersion = "1.2.5-SNAPSHOT"
 
 libraryDependencies ++= Seq(
   ws,

--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,8 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala, RiffRaffArtifact
 
     javaOptions in Universal ++= Seq(
       "-Dpidfile.path=/dev/null"
-    )
+    ),
+
+    pipelineStages := Seq(digest)
   )
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,5 +8,6 @@ panda.system="atom-workshop"
 
 parsers.text.maxLength=200kB
 
+play.filters.headers.contentSecurityPolicy="default-src 'self' 'unsafe-eval' 'unsafe-inline' data: https:"
 // No stage-specific config should go here!
 // DEV config goes in ~/.gu/.configuration-magic/atom-workshop.conf and CODE/PROD config lives in dynamo

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,6 +8,6 @@ panda.system="atom-workshop"
 
 parsers.text.maxLength=200kB
 
-play.filters.headers.contentSecurityPolicy="default-src 'self' 'unsafe-eval' 'unsafe-inline' data: https:"
+play.filters.headers.contentSecurityPolicy="default-src 'self' 'unsafe-eval' 'unsafe-inline' data: https: wss:"
 // No stage-specific config should go here!
 // DEV config goes in ~/.gu/.configuration-magic/atom-workshop.conf and CODE/PROD config lives in dynamo

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,8 @@ logLevel := Level.Warn
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.6" artifacts (Artifact("jdeb", "jar", "jar"))
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.17")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
  addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,6 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
- addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.1")

--- a/public/js/services/AtomsApi.js
+++ b/public/js/services/AtomsApi.js
@@ -21,7 +21,8 @@ export default {
         credentials: 'same-origin',
         body: JSON.stringify(atomInfo),
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Csrf-Token': window.guardian.csrf.token
         }
       }
     );
@@ -35,7 +36,8 @@ export default {
         credentials: 'same-origin',
         body: JSON.stringify(atom),
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Csrf-Token': window.guardian.csrf.token
         }
       }
     );
@@ -77,7 +79,8 @@ export default {
         credentials: 'same-origin',
         body: JSON.stringify(atom),
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Csrf-Token': window.guardian.csrf.token
         }
       }
     );

--- a/public/js/services/TargetingApi.js
+++ b/public/js/services/TargetingApi.js
@@ -38,7 +38,8 @@ export const createTarget = (targetObject) => {
       mode: 'cors',
       body: JSON.stringify(targetingObjectWithContentChange),
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'Csrf-Token': window.guardian.csrf.token
       }
     }
   );

--- a/public/js/services/WorkflowApi.js
+++ b/public/js/services/WorkflowApi.js
@@ -66,7 +66,8 @@ export default {
         mode: 'cors',
         body: JSON.stringify(payload),
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Csrf-Token': window.guardian.csrf.token
         }
       }
     );


### PR DESCRIPTION
## What does this change?

Upgrades to Play 2.6.  Requires an upgrade to atom-maker (https://github.com/guardian/atom-maker/pull/62) before it can be deployed.

Out of the box Play 2.6 only accepts requests with the correct `Host` header, which is a bit of a pain and provides little security benefit, so it has been disabled.

Play 2.6 also has a very strict Content-Security-Policy, which I've replaced with something more permissive.

Tested locally and on CODE.
