### PR TITLE
Double CAPI tags query to 200

### DIFF
--- a/public/js/services/capi.js
+++ b/public/js/services/capi.js
@@ -3,7 +3,7 @@ import { uriEncodeParams, sanitiseQuery } from '../util/uriEncodeParams';
 
 export const searchTags = (searchText) => {
   return pandaFetch(
-    `/support/capi/tags?web-title=${searchText}&page-size=100`,
+    `/support/capi/tags?web-title=${searchText}&page-size=200`,
     {
       method: 'get',
       credentials: 'same-origin',


### PR DESCRIPTION
## What does this change?

Searching for some tags can include a lot of responses... eg. search for France returns 120 responses, and France (topic) is not in the top 100. As you can't get more specific, this means that you can no longer select France as a topic for an atom. This PR doubles the limit to 200 to allow picking France until we can have a better, longer term solution (sorting, paginating, etc.)

## How to test

On CODE, france only returns 90 results, so France can always be found. Try searching "Fra" and looking for "Fran Roots (contributor)" - they should be around 110th result, so visible with this change.

## How can we measure success?

Editorial are unblocked

## Have we considered potential risks?

This problem will happen again as more tags are added. Composer manages to sort the results in a sensible fashion ("France" is at the top of the results, so can never drop off the bottom of any paging). Can atom-workshop do the same?
