### PR TITLE
Upgrade to sbt 1.6.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
 )
 
 resolvers ++= Seq(
-  "Sonatype OSS Snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/",
+  "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/",
     Resolver.sonatypeRepo("snapshots")
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,10 +2,10 @@ logLevel := Level.Warn
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.6" artifacts (Artifact("jdeb", "jar", "jar"))
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.3")


### PR DESCRIPTION
## What does this change?

Fairly minimal changes to upgrade to SBT 1.6.2 in order to resolve jnotify issue on M1 macs.  

- Switched sonatype resolver to be https, because SBT wasn't happy with http.
- Bumped sbt-digest because 1.1.1 isn't published for SBT 1.x
- Bumping the patch release of Play was probably unnecessary but equally not a bad thing to do anyway.

NB- I haven't fixed any deprecation warnings (sorry).
