### PR TITLE
Add CSRF token header to delete requests

### DIFF
--- a/public/js/services/AtomsApi.js
+++ b/public/js/services/AtomsApi.js
@@ -51,7 +51,8 @@ export default {
         credentials: 'same-origin',
         body: JSON.stringify(atom),
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Csrf-Token': window.guardian.csrf.token
         }
       }
     );
@@ -65,7 +66,8 @@ export default {
         credentials: 'same-origin',
         body: JSON.stringify(atom),
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'Csrf-Token': window.guardian.csrf.token
         }
       }
     );


### PR DESCRIPTION
## What does this change?

At the moment, taking down or deleting atoms fails with a CSRF error: `[CSRF] Check failed because application/json request`. That's because both of these requests do not include tokens, required as a result of the migration to Play 2.6 in #312. 

This PR adds CSRF tokens to the remaining mutating requests to atom-workshop on the client.

## How to test

Running locally or in CODE, try to take down and delete an atom. Does it work as expected?