### PR TITLE
Add trailing slash back into url config

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -21,8 +21,8 @@ class Config(initialConfiguration: Configuration, identity: AppIdentity) {
   // Service URLs
   val gridUrl = s"https://media.${if (!stage.contentEquals("PROD")) "test.dev-"}gutools.co.uk"
   val composerUrl = s"https://composer.$serviceDomain"
-  val viewerUrl = s"https://viewer.$serviceDomain"
-  val targetingUrl = s"https://targeting.$serviceDomain"
+  val viewerUrl = s"https://viewer.$serviceDomain/"
+  val targetingUrl = s"https://targeting.$serviceDomain/"
   val workflowUrl = s"https://workflow.$serviceDomain"
   val visualsUrl = s"https://charts.$domain"
 


### PR DESCRIPTION
## What does this change?
The original config had trailing slashes for the targeting and viewer urls and removing these is causing things to break in the frontend. Adding them back in for now, so things are not broken in PROD