### PR TITLE
Do not interpolate unit in URL template

### DIFF
--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -19,7 +19,7 @@ class Config(initialConfiguration: Configuration, identity: AppIdentity) {
   val serviceDomain: String = domainFromStage(effectiveStage)
 
   // Service URLs
-  val gridUrl = s"https://media.${if (!stage.contentEquals("PROD")) "test.dev-"}gutools.co.uk"
+  val gridUrl = s"https://media.${if (!stage.contentEquals("PROD")) "test.dev-" else ""}gutools.co.uk"
   val composerUrl = s"https://composer.$serviceDomain"
   val viewerUrl = s"https://viewer.$serviceDomain/"
   val targetingUrl = s"https://targeting.$serviceDomain/"


### PR DESCRIPTION
## What does this change?

Do not interpolate unit in the Grid URL template in production, which currently looks like `media.()gutools`, breaking the link. It's because our if statement returns `Unit` on the unhappy path, not `""`:

```scala
Welcome to Scala 3.2.1 (1.8.0_342, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                              
scala> println(s"oh${()}no")
oh()no
```

## How to test

Difficult to test outside of PROD, but as long as it compiles we should be OK.