### PR TITLE
Improve error handling when an atom cannot be updated due to a version conflict

### DIFF
--- a/app/db/AtomWorkshopDB.scala
+++ b/app/db/AtomWorkshopDB.scala
@@ -1,19 +1,22 @@
 package db
 
 import cats.syntax.either._
-import com.gu.atom.data.{DataStoreResultUtil, DynamoDataStore, IDNotFound}
+import com.gu.atom.data.{DataStoreResultUtil, DynamoDataStore, IDNotFound, VersionConflictError}
 import com.gu.contentatom.thrift.{Atom, AtomType}
 import com.gu.pandomainauth.model.User
-import models.{AtomAPIError, AtomWorkshopDynamoDatastoreError, UnknownAtomError}
+import models.{AtomAPIError, AtomWorkshopDynamoConflictError, AtomWorkshopDynamoDatastoreError, UnknownAtomError}
 import play.api.Logging
 import util.AtomLogic._
 
-trait AtomWorkshopDBAPI {
+trait AtomWorkshopDBAPI extends Logging {
 
   def transformAtomLibResult[T](atomType: AtomType, id: String, result: DataStoreResultUtil.DataStoreResult[T]): Either[AtomAPIError, T] = result match {
     case Left(IDNotFound) => Left(UnknownAtomError(atomType, id))
+    case Left(VersionConflictError(_)) => Left(AtomWorkshopDynamoConflictError)
     case Left(e) => Left(AtomWorkshopDynamoDatastoreError(e.msg))
-    case Right(r) => Right(r)
+    case Right(r) =>
+      logger.info(s"Successfully updated atom of type ${atomType.name} with id $id")
+      Right(r)
   }
 
   def createAtom(datastore: DynamoDataStore, atomType: AtomType, user: User, atom: Atom): Either[AtomAPIError, Atom]
@@ -46,7 +49,6 @@ class AtomWorkshopDB() extends AtomWorkshopDBAPI with Logging {
   def updateAtom(datastore: DynamoDataStore, atom: Atom): Either[AtomAPIError, Atom] = {
     try {
       val result = datastore.updateAtom(atom)
-      logger.info(s"Successfully updated atom of type ${atom.atomType.name} with id ${atom.id}")
       transformAtomLibResult(atom.atomType, atom.id, result)
     } catch {
       case e: Exception => processException(e)

--- a/app/models/APIResponse.scala
+++ b/app/models/APIResponse.scala
@@ -14,7 +14,7 @@ object AtomWorkshopAPIResponse{
 object APIResponse extends Results with Logging {
   def apiErrorToResult(e: AtomAPIError) = {
     logger.error(e.msg)
-    InternalServerError(AtomWorkshopAPIResponse(e.msg).asJson.noSpaces)
+    e.status(AtomWorkshopAPIResponse(e.msg).asJson.noSpaces)
   }
 
   def apply[T](result: Either[AtomAPIError, T])(implicit encoder: Encoder[T]): Result = {

--- a/app/models/Errors.scala
+++ b/app/models/Errors.scala
@@ -1,8 +1,9 @@
 package models
 
 import com.gu.contentatom.thrift.AtomType
+import models.APIResponse.{Conflict, InternalServerError}
 
-sealed abstract class AtomAPIError(val msg: String)
+sealed abstract class AtomAPIError(val msg: String, val status: APIResponse.Status = InternalServerError)
 
 case object InvalidAtomTypeError extends AtomAPIError("Atom type not valid - did you make a typo? Correct examples: 'cta', 'media")
 case class UnknownAtomError(atomType: AtomType, id: String) extends AtomAPIError(s"Unknown atom $atomType/$id")
@@ -11,6 +12,7 @@ case object DeleteAtomFromPreviewError extends AtomAPIError("Could not delete at
 case class CreateAtomDynamoError(atomJson: String, message: String) extends AtomAPIError(s"Error thrown by Dynamo when attempting to create atom. JSON of atom: $atomJson, error message: $message")
 case class AmazonDynamoError(message: String) extends AtomAPIError(s"Error thrown by Dynamo: $message")
 case class AtomWorkshopDynamoDatastoreError(message: String) extends AtomAPIError(message)
+case object AtomWorkshopDynamoConflictError extends AtomAPIError("Could not apply update due to a version conflict", Conflict)
 case class ExplainerDynamoDatastoreError(message: String) extends AtomAPIError(message)
 case class AtomJsonParsingError(message: String) extends AtomAPIError(s"Failed to parse Json string with error: $message")
 case class AtomThriftDeserialisingError(message: String) extends AtomAPIError(s"Failed to deserialise JSON into thrift with error: $message")

--- a/public/js/actions/AtomActions/updateAtom.js
+++ b/public/js/actions/AtomActions/updateAtom.js
@@ -18,11 +18,11 @@ function receiveAtomUpdate(atom) {
   };
 }
 
-function errorUpdatingAtom(error) {
+function errorUpdatingAtom(error, message) {
   logError(error);
   return {
     type:       'SHOW_ERROR',
-    message:    'Could not update atom',
+    message:    message,
     error:      error,
     receivedAt: Date.now()
   };
@@ -34,7 +34,12 @@ function _updateAtom(dispatch, atom) {
         .then(atom => {
           dispatch(receiveAtomUpdate(atom));
         })
-        .catch(error => dispatch(errorUpdatingAtom(error)));
+        .catch(error => {
+          const defaultError = 'Could not update atom';
+          const conflictError = 'Could not apply updates as another user (or tab) is currently editing this atom';
+          const message = error.status === 409 ? conflictError : defaultError;
+          dispatch(errorUpdatingAtom(error, message));
+        });
 }
 
 const _debouncedUpdate = _debounce(500, _updateAtom);


### PR DESCRIPTION
## What does this change?

We (@guardian/devx-reliability) noticed that this application is serving a (relatively) high percentage of 5XX errors[^1]. Most of these errors seem to occur due to a server side safety check which prevents users from accidentally overwriting changes that have been stored in the database since the client last fetched the atom. In my opinion, this should be treated as a client side error and not a server side error (i.e. the server is working as desired), so this PR modifies the code to return a [409](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409) instead of a 500 in this scenario.

Although there could be a number of explanations for this client side error, I suspect that many of these errors could just be due to multiple users (or the same user with multiple tabs open) editing an atom simultaneously. Analysis of the [application logs](https://logs.gutools.co.uk/s/editorial-tools/goto/44d76920-f304-11ed-84b5-9796daab3a37) suggests that the same users are often repeatedly attempting to update an atom in this state. I suspect these repeated attempts are partly due to the ambiguous error message that is currently displayed, so this PR also modifies the error message to try to explain the problem to users more clearly. That said, I don't have any UX expertise so any feedback on the new error message would be appreciated! 

## How to test

I have deployed this change to `CODE` and attempted to edit the same atom in multiple tabs. When doing this the new error message is displayed as expected (see screenshots below).

## How can we measure success?

* The Availability SLI for this service (as seen [here](https://metrics.gutools.co.uk/d/P0AtBxJVk/sli-dashboard-summary-view?orgId=1)) should improve as we will be serving fewer 5XX errors
* Hopefully we will also see fewer messages related to version conflicts in the logs (if the new message works as intended users won't continue attempting to update the atom, as they'll understand that it is not going to work until they refresh/close other tabs)

## Have we considered potential risks?

I don't think there are any particular risks associated with this PR.

## Images

**Before:**

<img width="1057" alt="image" src="https://github.com/guardian/atom-workshop/assets/19384074/0389cdba-4f04-4d99-84ba-82b2bd706a44">

**After:**

<img width="1053" alt="image" src="https://github.com/guardian/atom-workshop/assets/19384074/15bb722b-d0dd-4ccf-aca2-d4baea5721bc">

## Accessibility

As I have only changed error message copy I have not conducted any testing related to accessibility.

[^1]: This means that it is flagged as a problem in our [Availability SLI dashboard](https://metrics.gutools.co.uk/d/P0AtBxJVk/sli-dashboard-summary-view?orgId=1).
