### PR TITLE
Play 3.0 upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ scalaVersion := "2.13.12"
 
 libraryDependencies ++= dependencies
 
-resolvers ++= Resolver.sonatypeOssRepos("snapshots")
+resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 routesGenerator := InjectedRoutesGenerator
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object Dependencies {
   lazy val awsVersion = "1.11.678"
-  lazy val atomLibVersion = "2.0.0"
+  lazy val atomLibVersion = "3.0.0-PREVIEW.play-30.2024-03-12T1559.ba68b556"
   lazy val jacksonVersion = "2.13.4"
   lazy val jacksonDatabindVersion = "2.13.4.2"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ logLevel := Level.Warn
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.6" artifacts Artifact("jdeb", "jar", "jar")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.1")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 


### PR DESCRIPTION
## What does this change?

Upgrades from Play 2.9 to 3.0. This is a fairly small change since the only difference between these versions is Akka vs Pekko
