### PR TITLE
access permissions logging

### DIFF
--- a/app/controllers/PanDomainAuthActions.scala
+++ b/app/controllers/PanDomainAuthActions.scala
@@ -16,7 +16,7 @@ trait PanDomainAuthActions extends AuthActions with Logging {
 
     if (!isValid) {
       logger.warn(s"User ${authedUser.user.email} is not valid")
-    } else if (!canAccess && ! canDeleteAtom) {
+    } else if (!canAccess && !canDeleteAtom) {
       logger.warn(s"User ${authedUser.user.email} has no atom workshop permissions")
     } else if (!canAccess) {
       logger.warn(s"User ${authedUser.user.email} does not have atom_workshop_access permission")

--- a/app/controllers/PanDomainAuthActions.scala
+++ b/app/controllers/PanDomainAuthActions.scala
@@ -1,12 +1,31 @@
 package controllers
 
+import com.gu.pandomainauth.PanDomain
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
+import play.api.Logging
+import services.Permissions
 
-trait PanDomainAuthActions extends AuthActions {
+trait PanDomainAuthActions extends AuthActions with Logging {
 
-  override def validateUser(authedUser: AuthenticatedUser): Boolean =
-    (authedUser.user.email endsWith "@guardian.co.uk") && authedUser.multiFactor
+  override def validateUser(authedUser: AuthenticatedUser): Boolean = {
+
+    val isValid = PanDomain.guardianValidation(authedUser)
+    val canAccess = permissions.canAccess(authedUser)
+    val canDeleteAtom = permissions.canDeleteAtom(authedUser)
+
+    if (!isValid) {
+      logger.warn(s"User ${authedUser.user.email} is not valid")
+    } else if (!canAccess && ! canDeleteAtom) {
+      logger.warn(s"User ${authedUser.user.email} has no atom workshop permissions")
+    } else if (!canAccess) {
+      logger.warn(s"User ${authedUser.user.email} does not have atom_workshop_access permission")
+    }
+
+    isValid // TODO && canAccess
+  }
 
   override def authCallbackUrl: String
+
+  def permissions: Permissions
 }

--- a/app/services/Permissions.scala
+++ b/app/services/Permissions.scala
@@ -1,14 +1,28 @@
 package services
 
+import com.gu.pandomainauth.model.AuthenticatedUser
 import com.gu.permissions.{PermissionDefinition, PermissionsConfig, PermissionsProvider}
 import config.AWS
 
 class Permissions(stage: String) {
-  private val app = "atom-maker"
+  private val legacyApp = "atom-maker" // used for old permissions, shared with MAM. TODO should these be separated?
+  private val app = "atom-workshop"
+
+  private val deleteAtom = PermissionDefinition(name = "delete_atom", legacyApp)
+  private val access = PermissionDefinition(name = "atom_workshop_access", app)
 
   private val permissionDefinitions = Map(
-    "deleteAtom" -> PermissionDefinition(name = "delete_atom", app)
+    "deleteAtom" -> deleteAtom,
+    "access" -> access
   )
+
+  def canAccess(authedUser: AuthenticatedUser): Boolean = {
+    permissions.hasPermission(access, authedUser.user.email)
+  }
+
+  def canDeleteAtom(authedUser: AuthenticatedUser): Boolean = {
+    permissions.hasPermission(deleteAtom, authedUser.user.email)
+  }
 
   private val permissions: PermissionsProvider = PermissionsProvider(PermissionsConfig(stage, AWS.region.getName, AWS.credentials))
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     "com.gu" %% "editorial-permissions-client" % "2.15",
     "com.gu" %% "simple-configuration-ssm" % "1.5.6",
     "com.gu" %% "fezziwig" % "1.6",
-    "com.gu" %% "pan-domain-auth-play_2-9" % "3.0.1",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "3.0.1",
     "io.circe" %% "circe-parser" % "0.14.5",
     "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
     "com.gu" %% "content-api-client-aws" % "0.7",

--- a/public/js/components/Header/DeleteAtom.js
+++ b/public/js/components/Header/DeleteAtom.js
@@ -9,6 +9,7 @@ export default class DeleteAtom extends React.Component {
   };
 
   // the permissions are also validated on the server-side for each request
+  // TODO not currently true - must update server to actually do the validation!! ^
   permissions = getStore().getState().config.permissions;
   showActions = this.permissions.deleteAtom;
 


### PR DESCRIPTION
Requires https://github.com/guardian/permissions/pull/195

## What does this change?

Perform logging of user's access level, both with the delete permission (currently the only other permission respected by Atom-workshop) and solely by the access permission.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
