### PR TITLE
enforce atom_workshop_access permissions

### DIFF
--- a/app/controllers/PanDomainAuthActions.scala
+++ b/app/controllers/PanDomainAuthActions.scala
@@ -22,7 +22,7 @@ trait PanDomainAuthActions extends AuthActions with Logging {
       logger.warn(s"User ${authedUser.user.email} does not have atom_workshop_access permission")
     }
 
-    isValid // TODO && canAccess
+    isValid && canAccess
   }
 
   override def authCallbackUrl: String

--- a/app/controllers/PanDomainAuthActions.scala
+++ b/app/controllers/PanDomainAuthActions.scala
@@ -5,6 +5,8 @@ import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
 import play.api.Logging
 import services.Permissions
+import play.api.mvc.{RequestHeader, Result}
+import play.api.mvc.Results.Forbidden
 
 trait PanDomainAuthActions extends AuthActions with Logging {
 
@@ -23,6 +25,10 @@ trait PanDomainAuthActions extends AuthActions with Logging {
     }
 
     isValid && canAccess
+  }
+
+  override def showUnauthedMessage(message: String)(implicit request: RequestHeader): Result = {
+    Forbidden(views.html.authError(message))
   }
 
   override def authCallbackUrl: String

--- a/app/views/authError.scala.html
+++ b/app/views/authError.scala.html
@@ -1,0 +1,13 @@
+@(message: String)
+<!DOCTYPE html>
+<html>
+  <head lang="en">
+    <meta charset="UTF-8">
+    <title>Atom Workshop - access denied</title>
+  </head>
+  <body>
+    <h1>Atom Workshop - access denied</h1>
+    <p>@message</p>
+    <p>If you require access to the Atom Workshop tool, please contact <a href="mailto:central.production@@theguardian.com">Central Production</a> for assistance</p>
+  </body>
+</html>


### PR DESCRIPTION
Does what it says in the title.

Follow up to #354 

atom_workshop_access has been added to the content_* permissions groups, and all known users are members of one of those groups, so this shouldn't impact any users.