### PR TITLE
Upgrade to Panda v5.0.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     "com.gu" %% "editorial-permissions-client" % "2.15",
     "com.gu" %% "simple-configuration-ssm" % "1.5.6",
     "com.gu" %% "fezziwig" % "1.6",
-    "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "5.0.0",
     "io.circe" %% "circe-parser" % "0.14.5",
     "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
     "com.gu" %% "content-api-client-aws" % "0.7",


### PR DESCRIPTION
Although this release is a major-version-bump (from 4.0.0 to [5.0.0](https://github.com/guardian/pan-domain-authentication/releases/tag/v5.0.0)) this new version has no new functionality, just a few refactors and some dependency changes. The `gha-scala-library-release-workflow` detected potential binary-incompatible changes, and so allocated a major-version-bump, but any project upgrading to Panda v5 from v4 won't need to make any code changes to adapt to the new version.

Verified by [deploy](https://riffraff.gutools.co.uk/deployment/view/49e31018-2173-4ae3-a007-c1b6cecfd238) to CODE - Panda auth still works:

https://github.com/user-attachments/assets/e1f3a55e-1652-454f-b7ba-421f0f81a9aa

### See also

* https://github.com/guardian/atom-workshop/pull/359