### PR TITLE
Upgrade to Panda v7 - support key rotation

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,6 +1,6 @@
 import com.gu.AppIdentity
 import com.gu.atom.play.ReindexController
-import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.pandomainauth.{PanDomainAuthSettingsRefresher, S3BucketLoader}
 import config.{AWS, Config}
 import controllers.{AssetsComponents, ExplainerReindexController, PanDomainAuthActions}
 import db.{AtomDataStores, AtomWorkshopDB, ExplainerDB}
@@ -30,12 +30,10 @@ class AppComponents(context: Context, identity: AppIdentity)
 
     override def controllerComponents: ControllerComponents = AppComponents.this.controllerComponents
 
-    override val panDomainSettings: PanDomainAuthSettingsRefresher = new PanDomainAuthSettingsRefresher(
+    override val panDomainSettings: PanDomainAuthSettingsRefresher = PanDomainAuthSettingsRefresher(
       domain = config.pandaDomain,
       system = config.pandaSystem,
-      bucketName = "pan-domain-auth-settings",
-      settingsFileKey = s"${config.pandaDomain}.settings",
-      s3Client = AWS.S3Client,
+      S3BucketLoader.forAwsSdkV1(AWS.S3Client, "pan-domain-auth-settings")
     )
 
     override def permissions: Permissions = appPermissions

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -30,7 +30,7 @@ class AppComponents(context: Context, identity: AppIdentity)
 
     override def controllerComponents: ControllerComponents = AppComponents.this.controllerComponents
 
-    override def panDomainSettings: PanDomainAuthSettingsRefresher = new PanDomainAuthSettingsRefresher(
+    override val panDomainSettings: PanDomainAuthSettingsRefresher = new PanDomainAuthSettingsRefresher(
       domain = config.pandaDomain,
       system = config.pandaSystem,
       bucketName = "pan-domain-auth-settings",

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,8 @@ libraryDependencies ++= dependencies
 
 routesGenerator := InjectedRoutesGenerator
 
+resolvers ++= Resolver.sonatypeOssRepos("releases")
+
 lazy val root = (project in file(".")).enablePlugins(PlayScala, JDebPackaging, SystemdPlugin)
   .settings(Defaults.coreDefaultSettings: _*)
   .settings(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     "com.gu" %% "editorial-permissions-client" % "2.15",
     "com.gu" %% "simple-configuration-ssm" % "1.5.6",
     "com.gu" %% "fezziwig" % "1.6",
-    "com.gu" %% "pan-domain-auth-play_3-0" % "5.0.0",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "6.0.0-PREVIEW.support-accepting-multiple-public-keys.2024-09-12T0925.97cd6456",
     "io.circe" %% "circe-parser" % "0.14.5",
     "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
     "com.gu" %% "content-api-client-aws" % "0.7",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     "com.gu" %% "editorial-permissions-client" % "2.15",
     "com.gu" %% "simple-configuration-ssm" % "1.5.6",
     "com.gu" %% "fezziwig" % "1.6",
-    "com.gu" %% "pan-domain-auth-play_3-0" % "6.0.0-PREVIEW.support-accepting-multiple-public-keys.2024-09-12T1504.6e11a68d",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
     "io.circe" %% "circe-parser" % "0.14.5",
     "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
     "com.gu" %% "content-api-client-aws" % "0.7",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     "com.gu" %% "editorial-permissions-client" % "2.15",
     "com.gu" %% "simple-configuration-ssm" % "1.5.6",
     "com.gu" %% "fezziwig" % "1.6",
-    "com.gu" %% "pan-domain-auth-play_3-0" % "6.0.0-PREVIEW.support-accepting-multiple-public-keys.2024-09-12T1117.a6ae5e80",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "6.0.0-PREVIEW.support-accepting-multiple-public-keys.2024-09-12T1504.6e11a68d",
     "io.circe" %% "circe-parser" % "0.14.5",
     "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
     "com.gu" %% "content-api-client-aws" % "0.7",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     "com.gu" %% "editorial-permissions-client" % "2.15",
     "com.gu" %% "simple-configuration-ssm" % "1.5.6",
     "com.gu" %% "fezziwig" % "1.6",
-    "com.gu" %% "pan-domain-auth-play_3-0" % "6.0.0-PREVIEW.support-accepting-multiple-public-keys.2024-09-12T0925.97cd6456",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "6.0.0-PREVIEW.support-accepting-multiple-public-keys.2024-09-12T1117.a6ae5e80",
     "io.circe" %% "circe-parser" % "0.14.5",
     "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
     "com.gu" %% "content-api-client-aws" % "0.7",


### PR DESCRIPTION
This upgrades Panda from v5 to v7, allowing us to use [key rotation](https://github.com/guardian/pan-domain-authentication/pull/150).

As Atom Workshop is pretty standard user of Panda, the upgrade is pretty simple:

* Panda v6 requirements:
  * https://github.com/guardian/pan-domain-authentication/pull/155 requires `panDomainSettings` is a `val`, not a `def`
  * https://github.com/guardian/pan-domain-authentication/pull/151 introduced the new `S3BucketLoader` abstraction, which simplifies constructing a `PanDomainAuthSettingsRefresher` and means that Panda is no longer _tied_ to AWS SDK v1 - an alternative AWS SDK v2 implementation of `S3BucketLoader` could be introduced.

This has been [successfully deployed](https://riffraff.gutools.co.uk/deployment/view/86b7ccf9-7117-439c-9c8c-0edbcfb351b0) to https://atomworkshop.code.dev-gutools.co.uk/ at 55de0610d0fe034f7a7462d31bf991dbb6318e00, which is using https://github.com/guardian/pan-domain-authentication/pull/151/commits/4c87946a113b73f23e9e9b683082bdaeb49a5e2d.

## Testing

Using https://atomworkshop.code.dev-gutools.co.uk/ (running Panda with the version from https://github.com/guardian/pan-domain-authentication/pull/151) in the same browser as https://composer.code.dev-gutools.co.uk/ (running standard Panda v4), I've verified that they both accept the same cookie, and don't need to reauth over the top of each-others cookie:


https://github.com/user-attachments/assets/5e2db226-2ab2-4d00-af1c-d601e98c81a2

