### PR TITLE
Panda: Try out fix for creation of superfluous PanDomainAuthSettingsRefresher instances

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -30,7 +30,7 @@ class AppComponents(context: Context, identity: AppIdentity)
 
     override def controllerComponents: ControllerComponents = AppComponents.this.controllerComponents
 
-    override def panDomainSettings: PanDomainAuthSettingsRefresher = new PanDomainAuthSettingsRefresher(
+    override val panDomainSettings: PanDomainAuthSettingsRefresher = new PanDomainAuthSettingsRefresher(
       domain = config.pandaDomain,
       system = config.pandaSystem,
       bucketName = "pan-domain-auth-settings",

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,8 @@ libraryDependencies ++= dependencies
 
 routesGenerator := InjectedRoutesGenerator
 
+resolvers ++= Resolver.sonatypeOssRepos("releases")
+
 lazy val root = (project in file(".")).enablePlugins(PlayScala, JDebPackaging, SystemdPlugin)
   .settings(Defaults.coreDefaultSettings: _*)
   .settings(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     "com.gu" %% "editorial-permissions-client" % "2.15",
     "com.gu" %% "simple-configuration-ssm" % "1.5.6",
     "com.gu" %% "fezziwig" % "1.6",
-    "com.gu" %% "pan-domain-auth-play_3-0" % "5.0.0",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "6.0.0-PREVIEW.fix-creation-of-superfluous-PanDomainAuthSettingsRefresher-instances.2024-09-12T1544.61a193ca",
     "io.circe" %% "circe-parser" % "0.14.5",
     "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
     "com.gu" %% "content-api-client-aws" % "0.7",


### PR DESCRIPTION
Initially tried out in https://github.com/guardian/pan-domain-authentication/commit/6e11a68df89c24c3cc3df4d3b5135c57d067ea45, this is now separated out into its own PR, https://github.com/guardian/pan-domain-authentication/pull/155.
