### PR TITLE
Add tools audit tracking pixel

### DIFF
--- a/public/js/BaseApp.js
+++ b/public/js/BaseApp.js
@@ -16,15 +16,15 @@ import AtomRoot from './components/AtomRoot/AtomRoot';
 import ContentSuggestions from './components/ContentSuggestions/ContentSuggestions';
 import CommonsDivisions from './components/CommonsDivisions/CommonsDivisions';
 
-import {loadToolsAuditPixel, getUserTelemetryClientUrl} from './tools-audit-pixel';
+import {loadToolsAuditPixel} from './tools-audit-pixel';
 
 export const BaseApp = (props) => {
   React.useEffect(() => {
-    const trackPath = loadToolsAuditPixel()
+    const trackPath = loadToolsAuditPixel();
     trackPath(window.location.pathname);
-    props.history.listen((location, action) => {
+    props.history.listen((location, _action) => {
       trackPath(location.pathname);
-    })
+    });
   }, []);
   return (
     <Provider store={props.store}>
@@ -44,7 +44,7 @@ export const BaseApp = (props) => {
         </Route>
       </Router>
     </Provider>
-  )
+  );
 };
 
 BaseApp.propTypes = {

--- a/public/js/BaseApp.js
+++ b/public/js/BaseApp.js
@@ -22,7 +22,7 @@ export const BaseApp = (props) => {
   React.useEffect(() => {
     const trackPath = loadToolsAuditPixel();
     trackPath(window.location.pathname);
-    props.history.listen((location, _action) => {
+    props.history.listen((location) => {
       trackPath(location.pathname);
     });
   }, []);

--- a/public/js/BaseApp.js
+++ b/public/js/BaseApp.js
@@ -16,26 +16,36 @@ import AtomRoot from './components/AtomRoot/AtomRoot';
 import ContentSuggestions from './components/ContentSuggestions/ContentSuggestions';
 import CommonsDivisions from './components/CommonsDivisions/CommonsDivisions';
 
+import {loadToolsAuditPixel, getUserTelemetryClientUrl} from './tools-audit-pixel';
 
-export const BaseApp = (props) => (
-  <Provider store={props.store}>
-    <Router history={props.history}>
-      <Route path="/" component={Page}>
-        <Route path="/find" component={AtomList} />
-        <Route path="/create" component={AtomCreateTypeSelect} />
-        <Route path="/create/:atomType" component={AtomCreateGenericInfo} />
-        <Route path="/atoms/:atomType/:id" component={AtomRoot}>
-          <Route path="/atoms/:atomType/:id/edit" component={AtomEdit} />
-          <Route path="/atoms/:atomType/:id/stats" component={AtomStats} />
+export const BaseApp = (props) => {
+  React.useEffect(() => {
+    const trackPath = loadToolsAuditPixel()
+    trackPath(window.location.pathname);
+    props.history.listen((location, action) => {
+      trackPath(location.pathname);
+    })
+  }, []);
+  return (
+    <Provider store={props.store}>
+      <Router history={props.history}>
+        <Route path="/" component={Page}>
+          <Route path="/find" component={AtomList} />
+          <Route path="/create" component={AtomCreateTypeSelect} />
+          <Route path="/create/:atomType" component={AtomCreateGenericInfo} />
+          <Route path="/atoms/:atomType/:id" component={AtomRoot}>
+            <Route path="/atoms/:atomType/:id/edit" component={AtomEdit} />
+            <Route path="/atoms/:atomType/:id/stats" component={AtomStats} />
+          </Route>
+          <Route path="/external-atoms/:atomType/:id/link" component={ExternalAtom} />
+          <Route path="/suggestions" component={ContentSuggestions} />
+          <Route path="/commonsdivisions" component={CommonsDivisions} />
+          <IndexRedirect to="/find" />
         </Route>
-        <Route path="/external-atoms/:atomType/:id/link" component={ExternalAtom} />
-        <Route path="/suggestions" component={ContentSuggestions} />
-        <Route path="/commonsdivisions" component={CommonsDivisions} />
-        <IndexRedirect to="/find" />
-      </Route>
-    </Router>
-  </Provider>
-);
+      </Router>
+    </Provider>
+  )
+};
 
 BaseApp.propTypes = {
     store: PropTypes.object.isRequired,

--- a/public/js/tools-audit-pixel.js
+++ b/public/js/tools-audit-pixel.js
@@ -4,7 +4,7 @@ export function loadToolsAuditPixel() {
 		if (telemetryUrl) {
 			loadPixel(telemetryUrl, path);
 		}
-    })
+    });
 }
 
 function getUserTelemetryClientUrl(hostname) {

--- a/public/js/tools-audit-pixel.js
+++ b/public/js/tools-audit-pixel.js
@@ -1,0 +1,23 @@
+export function loadToolsAuditPixel() {
+    const telemetryUrl = getUserTelemetryClientUrl(window.location.hostname);
+    return ((path) => {
+		if (telemetryUrl) {
+			loadPixel(telemetryUrl, path);
+		}
+    })
+}
+
+function getUserTelemetryClientUrl(hostname) {
+	switch (hostname) {
+		case 'atomworkshop.gutools.co.uk': return 'https://user-telemetry.gutools.co.uk';
+		case 'atomworkshop.code.dev-gutools.co.uk': return 'https://user-telemetry.code.dev-gutools.co.uk';
+		case 'atomworkshop.local.dev-gutools.co.uk':
+		default:
+			return 'https://user-telemetry.local.dev-gutools.co.uk';
+	}
+}
+
+function loadPixel(telemetryUrl, path) {
+	const image = new Image();
+	image.src = `${telemetryUrl}/guardian-tool-accessed?app=atom-workshop&path=${path}`;
+}


### PR DESCRIPTION
## What does this change?

This PR adds the tools audit tracking pixel to atom workshop, to enable gathering more detailed usage information as part of the tools audit.

## How to test

- [deploy](https://riffraff.gutools.co.uk/deployment/deployAgain?project=editorial-tools%3Aatom-workshop&build=1605&stage=CODE&updateStrategy=MostlyHarmless&action=deploy) to [CODE](https://atomworkshop.code.dev-gutools.co.uk/)
- click around the interface, confirming that a request like `https://user-telemetry.code.dev-gutools.co.uk/guardian-tool-accessed?app=atom-workshop&path=<some-path>` is sent on every navigation
- check the [Tools Audit dashboard for atom-workshop-CODE](https://metrics.gutools.co.uk/d/aegzv59r9eghsd/tool-audit?orgId=1&var-path=All&var-interval=6h&var-chosen_apps=All&var-domain=atomworkshop.code.dev-gutools.co.uk&var-chosen_stacks=All&var-owners=All) and confirm the tracking pixel data is available for your navigations in the previous step
  - check that your user info has been recorded by inspecting the ”Top Users - Tracking Pixel” panel