### PR TITLE
AWS SDK v1 -> v2 migration

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -5,10 +5,10 @@ import config.{AWS, Config}
 import controllers.{AssetsComponents, ExplainerReindexController, PanDomainAuthActions}
 import db.{AtomDataStores, AtomWorkshopDB, ExplainerDB}
 import play.api.ApplicationLoader.Context
-import play.api.{BuiltInComponentsFromContext, Configuration}
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.{ControllerComponents, EssentialFilter}
+import play.api.{BuiltInComponentsFromContext, Configuration}
 import play.filters.HttpFiltersComponents
 import router.Routes
 import services.{AtomPublishers, Permissions}
@@ -33,7 +33,7 @@ class AppComponents(context: Context, identity: AppIdentity)
     override val panDomainSettings: PanDomainAuthSettingsRefresher = PanDomainAuthSettingsRefresher(
       domain = config.pandaDomain,
       system = config.pandaSystem,
-      S3BucketLoader.forAwsSdkV1(AWS.S3Client, "pan-domain-auth-settings")
+      S3BucketLoader.forAwsSdkV2(AWS.s3Client, "pan-domain-auth-settings")
     )
 
     override def permissions: Permissions = appPermissions

--- a/app/config/AWS.scala
+++ b/app/config/AWS.scala
@@ -1,33 +1,42 @@
 package config
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
-import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBClientBuilder}
-import com.amazonaws.services.kinesis.{AmazonKinesis, AmazonKinesisClientBuilder}
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, DefaultCredentialsProvider, ProfileCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.kinesis.KinesisClient
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
 
 object AWS {
-  lazy val region: Region = Option(Regions.getCurrentRegion).getOrElse(Region.getRegion(Regions.EU_WEST_1))
+  lazy val region: Region = Region.EU_WEST_1
 
-  lazy val credentials = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider("composer"),
-    new InstanceProfileCredentialsProvider(false)
+  lazy val credentials: DefaultCredentialsProvider = DefaultCredentialsProvider.builder()
+    .profileName("composer")
+    .build()
+
+  private[config] def capiPreviewCredentials(roleArn: String): AwsCredentialsProviderChain = AwsCredentialsProviderChain.of(
+    ProfileCredentialsProvider.create("capi"),
+    StsAssumeRoleCredentialsProvider.builder().refreshRequest(
+      AssumeRoleRequest.builder()
+        .roleArn(roleArn)
+        .roleSessionName("capi-preview")
+        .build()
+    ).build()
   )
 
-  lazy val dynamoDB: AmazonDynamoDB = AmazonDynamoDBClientBuilder
-    .standard()
-    .withCredentials(AWS.credentials)
-    .withRegion(region.getName)
+  lazy val dynamoDbClient: DynamoDbClient = DynamoDbClient.builder()
+    .credentialsProvider(credentials)
+    .region(region)
     .build()
 
-  lazy val kinesisClient: AmazonKinesis = AmazonKinesisClientBuilder.standard()
-    .withCredentials(AWS.credentials)
-    .withRegion(region.getName)
+  lazy val kinesisClient: KinesisClient = KinesisClient.builder()
+    .credentialsProvider(credentials)
+    .region(region)
     .build()
 
-  lazy val S3Client: AmazonS3 = AmazonS3ClientBuilder.standard()
-    .withCredentials(credentials)
-    .withRegion(region.getName)
+  lazy val s3Client: S3Client = S3Client.builder()
+    .credentialsProvider(credentials)
+    .region(region)
     .build()
 }

--- a/app/config/AWS.scala
+++ b/app/config/AWS.scala
@@ -5,6 +5,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.kinesis.KinesisClient
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.sts.StsClient
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
 
@@ -17,7 +18,7 @@ object AWS {
 
   private[config] def capiPreviewCredentials(roleArn: String): AwsCredentialsProviderChain = AwsCredentialsProviderChain.of(
     ProfileCredentialsProvider.create("capi"),
-    StsAssumeRoleCredentialsProvider.builder().refreshRequest(
+    StsAssumeRoleCredentialsProvider.builder().stsClient(stsClient).refreshRequest(
       AssumeRoleRequest.builder()
         .roleArn(roleArn)
         .roleSessionName("capi-preview")
@@ -36,6 +37,11 @@ object AWS {
     .build()
 
   lazy val s3Client: S3Client = S3Client.builder()
+    .credentialsProvider(credentials)
+    .region(region)
+    .build()
+
+  private lazy val stsClient = StsClient.builder()
     .credentialsProvider(credentials)
     .region(region)
     .build()

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -1,9 +1,8 @@
 package config
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProvider, AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
 import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
 import play.api.Configuration
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain
 
 class Config(initialConfiguration: Configuration, identity: AppIdentity) {
   val config = initialConfiguration.underlying
@@ -48,12 +47,7 @@ class Config(initialConfiguration: Configuration, identity: AppIdentity) {
   val capiPreviewIAMUrl: String = config.getString("capi.previewIAMUrl")
   val capiLiveUrl: String = config.getString("capi.liveUrl")
   val capiPreviewRole: String = config.getString("capi.previewRole")
-  val capiPreviewCredentials: AWSCredentialsProvider = {
-    new AWSCredentialsProviderChain(
-      new ProfileCredentialsProvider("capi"),
-      new STSAssumeRoleSessionCredentialsProvider.Builder(capiPreviewRole, "capi-preview").build()
-    )
-  }
+  val capiPreviewCredentials: AwsCredentialsProviderChain = AWS.capiPreviewCredentials(capiPreviewRole)
 
   // Presence
   val presenceEnabled: Boolean = getOptionalProperty("presence.enabled", config.getBoolean).getOrElse(true)

--- a/app/controllers/ExplainerReindexController.scala
+++ b/app/controllers/ExplainerReindexController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.gu.atom.data.DynamoDataStore
+import com.gu.atom.data.DynamoDataStoreV2
 import com.gu.atom.publish.{AtomReindexer, PreviewAtomReindexer, PublishedAtomReindexer}
 import com.gu.contentatom.thrift.{ContentAtomEvent, EventType}
 import config.Config
@@ -16,8 +16,8 @@ import scala.util.{Success, Try}
 class ExplainerReindexController(
   val wsClient: WSClient,
   explainerDB: ExplainerDBAPI,
-  previewDataStore: DynamoDataStore,
-  publishedDataStore: DynamoDataStore,
+  previewDataStore: DynamoDataStoreV2,
+  publishedDataStore: DynamoDataStoreV2,
   previewReindexer: PreviewAtomReindexer,
   publishedReindexer: PublishedAtomReindexer,
   config: Config,
@@ -59,7 +59,7 @@ class ExplainerReindexController(
     }
   }
 
-  private def run(datastore: DynamoDataStore, reindexer: AtomReindexer): Future[Int] = {
+  private def run(datastore: DynamoDataStoreV2, reindexer: AtomReindexer): Future[Int] = {
     explainerDB.listAtoms(datastore).fold(
       apiError => Future.failed(new RuntimeException(apiError.msg)),
       { atoms =>

--- a/app/controllers/Support.scala
+++ b/app/controllers/Support.scala
@@ -16,7 +16,7 @@ class Support(val controllerComponents: ControllerComponents, val wsClient: WSCl
 
   private val signer = new IAMSigner(
     credentialsProvider = config.capiPreviewCredentials,
-    awsRegion = AWS.region.getName
+    awsRegion = AWS.region.id
   )
 
   private def getHeaders(url: String): Seq[(String,String)] = signer.addIAMHeaders(headers = Map.empty, uri = URI.create(url)).toSeq

--- a/app/db/AtomDataStores.scala
+++ b/app/db/AtomDataStores.scala
@@ -1,25 +1,23 @@
 package db
 
 import com.gu.atom.data._
-import com.gu.atom.publish.{PreviewKinesisAtomReindexer, PublishedKinesisAtomReindexer}
+import com.gu.atom.publish.{PreviewKinesisAtomReindexerV2, PublishedKinesisAtomReindexerV2}
 import config.{AWS, Config}
 import models.{Live, Preview, Version}
 
 class AtomDataStores(config: Config) {
-  def getDataStore(version: Version): DynamoDataStore = version match {
+  def getDataStore(version: Version): DynamoDataStoreV2 = version match {
     case Live => publishedDataStore
     case Preview => previewDataStore
   }
 
-  val previewDataStore = new PreviewDynamoDataStore(AWS.dynamoDB, config.previewDynamoTableName)
-  val publishedDataStore = new PublishedDynamoDataStore(AWS.dynamoDB, config.publishedDynamoTableName)
-  
-  val explainerPreviewDataStore = new PreviewDynamoDataStore(AWS.dynamoDB, config.explainerPreviewDynamoTableName)
-  val explainerPublishedDataStore = new PublishedDynamoDataStore(AWS.dynamoDB, config.explainerPublishedDynamoTableName)
+  val previewDataStore = new PreviewDynamoDataStoreV2(AWS.dynamoDbClient, config.previewDynamoTableName)
+  val publishedDataStore = new PublishedDynamoDataStoreV2(AWS.dynamoDbClient, config.publishedDynamoTableName)
 
-  val reindexPreview: PreviewKinesisAtomReindexer =
-    new PreviewKinesisAtomReindexer(config.previewReindexKinesisStreamName, AWS.kinesisClient)
+  val explainerPreviewDataStore = new PreviewDynamoDataStoreV2(AWS.dynamoDbClient, config.explainerPreviewDynamoTableName)
+  val explainerPublishedDataStore = new PublishedDynamoDataStoreV2(AWS.dynamoDbClient, config.explainerPublishedDynamoTableName)
 
-  val reindexPublished: PublishedKinesisAtomReindexer =
-    new PublishedKinesisAtomReindexer(config.liveReindexKinesisStreamName, AWS.kinesisClient)
+  val reindexPreview = new PreviewKinesisAtomReindexerV2(config.previewReindexKinesisStreamName, AWS.kinesisClient)
+
+  val reindexPublished = new PublishedKinesisAtomReindexerV2(config.liveReindexKinesisStreamName, AWS.kinesisClient)
 }

--- a/app/db/AtomWorkshopDB.scala
+++ b/app/db/AtomWorkshopDB.scala
@@ -1,7 +1,6 @@
 package db
 
-import cats.syntax.either._
-import com.gu.atom.data.{DataStoreResultUtil, DynamoDataStore, IDNotFound, VersionConflictError}
+import com.gu.atom.data.{DataStoreResultUtil, DynamoDataStoreV2, IDNotFound, VersionConflictError}
 import com.gu.contentatom.thrift.{Atom, AtomType}
 import com.gu.pandomainauth.model.User
 import models.{AtomAPIError, AtomWorkshopDynamoConflictError, AtomWorkshopDynamoDatastoreError, UnknownAtomError}
@@ -19,20 +18,20 @@ trait AtomWorkshopDBAPI extends Logging {
       Right(r)
   }
 
-  def createAtom(datastore: DynamoDataStore, atomType: AtomType, user: User, atom: Atom): Either[AtomAPIError, Atom]
+  def createAtom(datastore: DynamoDataStoreV2, atomType: AtomType, user: User, atom: Atom): Either[AtomAPIError, Atom]
 
-  def getAtom(datastore: DynamoDataStore, atomType: AtomType, id: String): Either[AtomAPIError, Atom]
+  def getAtom(datastore: DynamoDataStoreV2, atomType: AtomType, id: String): Either[AtomAPIError, Atom]
 
-  def publishAtom(datastore: DynamoDataStore, user: User, newVersion: Atom): Either[AtomAPIError, Atom]
+  def publishAtom(datastore: DynamoDataStoreV2, user: User, newVersion: Atom): Either[AtomAPIError, Atom]
 
-  def updateAtom(datastore: DynamoDataStore, atom: Atom): Either[AtomAPIError, Atom]
+  def updateAtom(datastore: DynamoDataStoreV2, atom: Atom): Either[AtomAPIError, Atom]
 
-  def deleteAtom(datastore: DynamoDataStore, atomType: AtomType, id: String): Either[AtomAPIError, Atom]
+  def deleteAtom(datastore: DynamoDataStoreV2, atomType: AtomType, id: String): Either[AtomAPIError, Atom]
 }
 
 class AtomWorkshopDB() extends AtomWorkshopDBAPI with Logging {
 
-  def createAtom(datastore: DynamoDataStore, atomType: AtomType, user: User, atom: Atom): Either[AtomAPIError, Atom] = {
+  def createAtom(datastore: DynamoDataStoreV2, atomType: AtomType, user: User, atom: Atom): Either[AtomAPIError, Atom] = {
     logger.info(s"Attempting to create atom of type ${atomType.name} with id ${atom.id}")
     try {
       val result = datastore.createAtom(buildKey(atomType, atom.id), atom)
@@ -43,10 +42,10 @@ class AtomWorkshopDB() extends AtomWorkshopDBAPI with Logging {
     }
   }
 
-  def getAtom(datastore: DynamoDataStore, atomType: AtomType, id: String) =
+  def getAtom(datastore: DynamoDataStoreV2, atomType: AtomType, id: String) =
     transformAtomLibResult(atomType, id, datastore.getAtom(buildKey(atomType, id)))
 
-  def updateAtom(datastore: DynamoDataStore, atom: Atom): Either[AtomAPIError, Atom] = {
+  def updateAtom(datastore: DynamoDataStoreV2, atom: Atom): Either[AtomAPIError, Atom] = {
     try {
       val result = datastore.updateAtom(atom)
       transformAtomLibResult(atom.atomType, atom.id, result)
@@ -55,9 +54,9 @@ class AtomWorkshopDB() extends AtomWorkshopDBAPI with Logging {
     }
   }
 
-  def publishAtom(datastore: DynamoDataStore, user: User, newAtom: Atom): Either[AtomAPIError, Atom] = {
+  def publishAtom(datastore: DynamoDataStoreV2, user: User, newAtom: Atom): Either[AtomAPIError, Atom] = {
 
-    def checkAtomExistsInDatastore(datastore: DynamoDataStore, atomType: AtomType, id: String): Either[AtomAPIError, Boolean] =
+    def checkAtomExistsInDatastore(datastore: DynamoDataStoreV2, atomType: AtomType, id: String): Either[AtomAPIError, Boolean] =
       datastore.getAtom(buildKey(atomType, id)).fold({
         case IDNotFound => Right(false)
         case e => Left(AtomWorkshopDynamoDatastoreError(e.msg))
@@ -69,6 +68,6 @@ class AtomWorkshopDB() extends AtomWorkshopDBAPI with Logging {
     })
   }
 
-  def deleteAtom(datastore: DynamoDataStore, atomType: AtomType, id: String) =
+  def deleteAtom(datastore: DynamoDataStoreV2, atomType: AtomType, id: String) =
     transformAtomLibResult(atomType, id, datastore.deleteAtom(buildKey(atomType, id)))
 }

--- a/app/db/ExplainerDB.scala
+++ b/app/db/ExplainerDB.scala
@@ -1,18 +1,18 @@
 package db
 
-import com.gu.atom.data.DynamoDataStore
+import com.gu.atom.data.DynamoDataStoreV2
 import com.gu.contentatom.thrift.Atom
 import models.{AtomAPIError, ExplainerDynamoDatastoreError}
 import play.api.Logging
 import util.AtomLogic._
 
 trait ExplainerDBAPI {
-  def listAtoms(datastore: DynamoDataStore): Either[AtomAPIError, List[Atom]]
+  def listAtoms(datastore: DynamoDataStoreV2): Either[AtomAPIError, List[Atom]]
 }
 
 class ExplainerDB() extends ExplainerDBAPI with Logging {
 
-  def listAtoms(datastore: DynamoDataStore): Either[AtomAPIError, List[Atom]] = {
+  def listAtoms(datastore: DynamoDataStoreV2): Either[AtomAPIError, List[Atom]] = {
     logger.info(s"Attempting to read all explainers from ${datastore.getClass.getName}")
     try {
       val result = datastore.listAtoms

--- a/app/services/AtomPublishers.scala
+++ b/app/services/AtomPublishers.scala
@@ -1,6 +1,6 @@
 package services
 
-import com.gu.atom.publish.{AtomPublisher, LiveKinesisAtomPublisher, PreviewKinesisAtomPublisher}
+import com.gu.atom.publish.{AtomPublisher, LiveKinesisAtomPublisherV2, PreviewKinesisAtomPublisherV2}
 import com.gu.contentatom.thrift.{Atom, ContentAtomEvent, EventType}
 import config.{AWS, Config}
 import models.{AtomAPIError, KinesisPublishingFailed}
@@ -10,8 +10,8 @@ import play.api.Logging
 import scala.util.{Failure, Success}
 
 class AtomPublishers(config: Config) extends Logging {
-  val liveAtomPublisher = new LiveKinesisAtomPublisher(config.liveKinesisStreamName, AWS.kinesisClient)
-  val previewAtomPublisher = new PreviewKinesisAtomPublisher(config.previewKinesisStreamName, AWS.kinesisClient)
+  val liveAtomPublisher = new LiveKinesisAtomPublisherV2(config.liveKinesisStreamName, AWS.kinesisClient)
+  val previewAtomPublisher = new PreviewKinesisAtomPublisherV2(config.previewKinesisStreamName, AWS.kinesisClient)
 
   def sendKinesisEvent(atom: Atom, atomPublisher: AtomPublisher, eventType: EventType): Either[AtomAPIError, Unit] = {
     if (config.kinesisEnabled) {

--- a/app/services/Permissions.scala
+++ b/app/services/Permissions.scala
@@ -24,7 +24,7 @@ class Permissions(stage: String) {
     permissions.hasPermission(deleteAtom, authedUser.user.email)
   }
 
-  private val permissions: PermissionsProvider = PermissionsProvider(PermissionsConfig(stage, AWS.region.getName, AWS.credentials))
+  private val permissions: PermissionsProvider = PermissionsProvider(PermissionsConfig(stage, AWS.region.id(), AWS.credentials))
 
   def getAll(email: String): Map[String, Boolean] = permissionDefinitions.transform(
     (_, permission) => permissions.hasPermission(permission, email)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,8 @@
 import play.sbt.PlayImport.ws
-import sbt._
+import sbt.*
 
 object Dependencies {
-  lazy val awsVersion = "1.12.791"
+  lazy val awsVersion = "2.45.0"
   lazy val atomLibVersion = "11.0.0"
   lazy val jacksonVersion = "2.17.2"
   lazy val jacksonDatabindVersion = "2.17.2"
@@ -22,21 +22,18 @@ object Dependencies {
 
   val dependencies = jacksonOverrides ++ jacksonDatabindOverrides ++ Seq(
     ws,
-    "com.amazonaws" % "aws-java-sdk-core" % awsVersion,
-    "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
-    "com.amazonaws" % "aws-java-sdk-lambda" % awsVersion,
-    "com.amazonaws" % "aws-java-sdk-dynamodb" % awsVersion,
-    "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
-    "com.amazonaws" % "aws-java-sdk-kinesis" % awsVersion,
+    "software.amazon.awssdk" % "dynamodb" % awsVersion,
+    "software.amazon.awssdk" % "kinesis" % awsVersion,
+    "software.amazon.awssdk" % "sts" % awsVersion,
     "com.gu" %% "atom-manager-play" % atomLibVersion,
     "com.gu" %% "atom-publisher-lib" % atomLibVersion,
-    "com.gu" %% "editorial-permissions-client" % "2.15",
-    "com.gu" %% "simple-configuration-ssm" % "7.0.1",
+    "com.gu" %% "editorial-permissions-client" % "6.0.3",
+    "com.gu" %% "simple-configuration-ssm" % "10.0.2",
     "com.gu" %% "fezziwig" % "1.6",
-    "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
+    "com.gu" %% "pan-domain-auth-play_3-0" % "19.0.0",
     "io.circe" %% "circe-parser" % "0.14.5",
     "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
-    "com.gu" %% "content-api-client-aws" % "0.7",
+    "com.gu" %% "content-api-client-aws" % "1.0.1",
     "com.gu" %% "content-api-client" % "43.0.0"
   )
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Performs the AWS SDK migration from v1 to v2. v1 remains on the classpath as it is depended on by atom-maker libs as this version includes support for both v1 and v2. A future version will drop the support for v1 and it will be removed from the classpath at that point.

## How has this change been tested?

On CODE, creating a new atom and adding it to a Composer article.

## How can we measure success?

Atom-maker lib can drop support for the v1 SDK.

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
