### PR TITLE
Upgrade atom-maker lib to new v12 with updated reindexing logic

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -51,12 +51,10 @@ class AppComponents(context: Context, identity: AppIdentity)
   lazy val supportController = new controllers.Support(controllerComponents, wsClient, config, pandaAuthActions)
 
   lazy val reindex = new ReindexController(
-    atomDataStores.previewDataStore,
-    atomDataStores.publishedDataStore,
-    atomDataStores.reindexPreview,
-    atomDataStores.reindexPublished,
-    Configuration(config.config),
-    controllerComponents,
-    actorSystem
+    previewReindexer = atomDataStores.previewReindexer,
+    publishedReindexer = atomDataStores.publishedReindexer,
+    config = Configuration(config.config),
+    controllerComponents = controllerComponents,
+    system = actorSystem
   )
 }

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -39,6 +39,8 @@ class Config(initialConfiguration: Configuration, identity: AppIdentity) {
   // DynamoDB
   val previewDynamoTableName: String = config.getString("aws.dynamo.preview.tableName")
   val publishedDynamoTableName: String = config.getString("aws.dynamo.live.tableName")
+  val previewReindexDynamoTableName: String = config.getString("aws.dynamo.preview.reindexTableName")
+  val publishedReindexDynamoTableName: String = config.getString("aws.dynamo.live.reindexTableName")
 
   // CAPI
   val capiApiKey: String = config.getString("capi.apiKey")
@@ -50,8 +52,6 @@ class Config(initialConfiguration: Configuration, identity: AppIdentity) {
   // Presence
   val presenceEnabled: Boolean = getOptionalProperty("presence.enabled", config.getBoolean).getOrElse(true)
   val presenceDomain: String = getPropertyIfEnabled(presenceEnabled, "presence.domain")
-
-  val reindexApiKey: String = config.getString("reindexApiKey")
 
   def getOptionalProperty[T](path: String, getVal: String => T): Option[T] = {
     if (config.hasPath(path)) Some(getVal(path))

--- a/app/config/Config.scala
+++ b/app/config/Config.scala
@@ -39,8 +39,8 @@ class Config(initialConfiguration: Configuration, identity: AppIdentity) {
   // DynamoDB
   val previewDynamoTableName: String = config.getString("aws.dynamo.preview.tableName")
   val publishedDynamoTableName: String = config.getString("aws.dynamo.live.tableName")
-  val previewReindexDynamoTableName: String = config.getString("aws.dynamo.preview.reindexTableName")
-  val publishedReindexDynamoTableName: String = config.getString("aws.dynamo.live.reindexTableName")
+  val previewReindexDynamoTableName: String = getPropertyIfEnabled(kinesisEnabled, "aws.dynamo.preview.reindexTableName")
+  val publishedReindexDynamoTableName: String = getPropertyIfEnabled(kinesisEnabled, "aws.dynamo.published.reindexTableName")
 
   // CAPI
   val capiApiKey: String = config.getString("capi.apiKey")

--- a/app/controllers/App.scala
+++ b/app/controllers/App.scala
@@ -17,6 +17,8 @@ import com.gu.pandomainauth.model.{User => PandaUser}
 import services.{AtomPublishers, Permissions}
 import views.html.helper.CSRF
 
+import scala.concurrent.ExecutionContext
+
 class App(
            val controllerComponents: ControllerComponents,
            val config: Config,
@@ -33,7 +35,7 @@ class App(
 
   import pandaAuthActions.AuthAction
 
-  implicit val executionContext = controllerComponents.executionContext
+  implicit val executionContext: ExecutionContext = controllerComponents.executionContext
 
   private val previewDataStore = atomDataStores.getDataStore(Preview)
   private val publishedDataStore = atomDataStores.getDataStore(Live)

--- a/app/db/AtomDataStores.scala
+++ b/app/db/AtomDataStores.scala
@@ -1,7 +1,7 @@
 package db
 
 import com.gu.atom.data._
-import com.gu.atom.publish.{PreviewKinesisAtomReindexerV2, PublishedKinesisAtomReindexerV2}
+import com.gu.atom.reindex.{DynamoReindexDataStoreV2, PreviewKinesisAtomReindexerV2, PublishedKinesisAtomReindexerV2}
 import config.{AWS, Config}
 import models.{Live, Preview, Version}
 
@@ -14,7 +14,19 @@ class AtomDataStores(config: Config) {
   val previewDataStore = new PreviewDynamoDataStoreV2(AWS.dynamoDbClient, config.previewDynamoTableName)
   val publishedDataStore = new PublishedDynamoDataStoreV2(AWS.dynamoDbClient, config.publishedDynamoTableName)
 
-  val reindexPreview = new PreviewKinesisAtomReindexerV2(config.previewReindexKinesisStreamName, AWS.kinesisClient)
+  val previewReindexStore = new DynamoReindexDataStoreV2(AWS.dynamoDbClient, config.previewReindexDynamoTableName)
+  val publishedReindexStore = new DynamoReindexDataStoreV2(AWS.dynamoDbClient, config.publishedReindexDynamoTableName)
 
-  val reindexPublished = new PublishedKinesisAtomReindexerV2(config.liveReindexKinesisStreamName, AWS.kinesisClient)
+  val previewReindexer = new PreviewKinesisAtomReindexerV2(
+    streamName = config.previewReindexKinesisStreamName,
+    kinesis = AWS.kinesisClient,
+    atomDataStore = previewDataStore,
+    reindexDataStore = previewReindexStore)
+
+  val publishedReindexer = new PublishedKinesisAtomReindexerV2(
+    streamName = config.liveReindexKinesisStreamName,
+    kinesis = AWS.kinesisClient,
+    atomDataStore = publishedDataStore,
+    reindexDataStore = publishedReindexStore)
+
 }

--- a/app/util/AtomElementBuilders.scala
+++ b/app/util/AtomElementBuilders.scala
@@ -1,17 +1,17 @@
 package util
 
-import com.gu.contentatom.thrift.atom.cta.CTAAtom
-import com.gu.contentatom.thrift.atom.qanda.{QAndAAtom, QAndAItem}
-import com.gu.contentatom.thrift.atom.profile.ProfileAtom
-import com.gu.contentatom.thrift.atom.guide.GuideAtom
-import com.gu.contentatom.thrift.atom.timeline.TimelineAtom
-import com.gu.contentatom.thrift.atom.explainer.{DisplayType, ExplainerAtom}
+import com.gu.contentatom.thrift.atom.audio.AudioAtom
 import com.gu.contentatom.thrift.atom.commonsdivision.{CommonsDivision, Votes}
-import com.gu.contentatom.thrift.atom.audio.{AudioAtom, OffPlatform}
-import com.gu.contentatom.thrift.{User, _}
+import com.gu.contentatom.thrift.atom.cta.CTAAtom
+import com.gu.contentatom.thrift.atom.explainer.{DisplayType, ExplainerAtom}
+import com.gu.contentatom.thrift.atom.guide.GuideAtom
+import com.gu.contentatom.thrift.atom.profile.ProfileAtom
+import com.gu.contentatom.thrift.atom.qanda.{QAndAAtom, QAndAItem}
+import com.gu.contentatom.thrift.atom.timeline.TimelineAtom
+import com.gu.contentatom.thrift._
 import com.gu.pandomainauth.model.{User => PandaUser}
 import models.CreateAtomFields
-import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 
 object AtomElementBuilders {

--- a/app/util/AtomLogic.scala
+++ b/app/util/AtomLogic.scala
@@ -1,7 +1,6 @@
 package util
 
 import cats.syntax.either._
-import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException
 import com.gu.atom.data.DynamoCompositeKey
 import com.gu.contentatom.thrift._
 import com.gu.contententity.thrift.Entity
@@ -11,6 +10,7 @@ import io.circe.generic.auto._
 import io.circe.{DecodingFailure, ParsingFailure, parser, _}
 import models._
 import play.api.Logging
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException
 import util.AtomElementBuilders._
 
 object AtomLogic extends Logging {
@@ -31,7 +31,7 @@ object AtomLogic extends Logging {
     val atomApiError = exception match {
       case e: ParsingFailure => AtomJsonParsingError(e.message)
       case e: DecodingFailure => AtomThriftDeserialisingError(e.message)
-      case e: AmazonDynamoDBException => AmazonDynamoError(e.getMessage)
+      case e: DynamoDbException => AmazonDynamoError(e.getMessage)
       case _ => UnexpectedExceptionError
     }
     logger.error(atomApiError.msg, exception)
@@ -58,7 +58,7 @@ object Parser extends Logging {
   import AtomLogic._
 
   //These implicits speed up compilation
-  private implicit val atomDecoder = {
+  private implicit val atomDecoder: Decoder[Atom] = {
     implicit val entityDecoder = Decoder[Entity]
     implicit val imageAssetDecoder = Decoder[ImageAsset]
     implicit val imageDecoder = Decoder[Image]

--- a/conf/routes
+++ b/conf/routes
@@ -42,6 +42,8 @@ POST    /reindex-preview                         com.gu.atom.play.ReindexControl
 POST    /reindex-publish                         com.gu.atom.play.ReindexController.newPublishedReindexJob()
 GET     /reindex-preview                         com.gu.atom.play.ReindexController.previewReindexJobStatus()
 GET     /reindex-publish                         com.gu.atom.play.ReindexController.publishedReindexJobStatus()
+DELETE  /reindex-preview                         com.gu.atom.play.ReindexController.cancelPreviewReindexJob()
+DELETE  /reindex-publish                         com.gu.atom.play.ReindexController.cancelPublishedReindexJob()
 
 # Commons divisions
 GET     /commonsdivisions                        controllers.App.index(placeholder = "")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 
 object Dependencies {
   lazy val awsVersion = "2.45.0"
-  lazy val atomLibVersion = "12.0.0-PREVIEW.anpageable-cancellable-atom-reindex.2026-05-29T1652.35adac95"
+  lazy val atomLibVersion = "12.0.0"
   lazy val jacksonVersion = "2.17.2"
   lazy val jacksonDatabindVersion = "2.17.2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 
 object Dependencies {
   lazy val awsVersion = "2.45.0"
-  lazy val atomLibVersion = "11.0.0"
+  lazy val atomLibVersion = "12.0.0-PREVIEW.anpageable-cancellable-atom-reindex.2026-05-29T1652.35adac95"
   lazy val jacksonVersion = "2.17.2"
   lazy val jacksonDatabindVersion = "2.17.2"
 
@@ -34,6 +34,7 @@ object Dependencies {
     "io.circe" %% "circe-parser" % "0.14.5",
     "net.logstash.logback" % "logstash-logback-encoder" % "6.6",
     "com.gu" %% "content-api-client-aws" % "1.0.1",
-    "com.gu" %% "content-api-client" % "43.0.0"
+    "com.gu" %% "content-api-client" % "43.0.0",
+    "joda-time" % "joda-time" % "2.14.2"
   )
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates atom-workshop to v12. Implement the updated atom reindexing classes (https://github.com/guardian/atom-maker/pull/146) which reindex atoms in batches, so we no longer need to fit the entire atom database into memory all at once.

## How has this change been tested?

Tested on CODE 

## How can we measure success?

With a successful reindex of atoms.
