### PR TITLE
remove explicit type declaration which causes NPE

### DIFF
--- a/app/util/AtomLogic.scala
+++ b/app/util/AtomLogic.scala
@@ -58,7 +58,7 @@ object Parser extends Logging {
   import AtomLogic._
 
   //These implicits speed up compilation
-  private implicit val atomDecoder: Decoder[Atom] = {
+  private implicit val atomDecoder = {
     implicit val entityDecoder = Decoder[Entity]
     implicit val imageAssetDecoder = Decoder[ImageAsset]
     implicit val imageDecoder = Decoder[Image]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Remove an explicit type declaration which was added while working on #409 

Having this type declaration apparently causes a null pointer exception at https://github.com/guardian/atom-workshop/blob/675c223caaf2189585e16430dca908f724709d8b/app/util/AtomLogic.scala#L83 when the decoder is passed as the implicit parameter.

I have no idea how, but this is the only even tangentially related change from this PR, and I have verified locally by trying to save an atom. When the implicit has an explicit type, we see a null pointer exception; when it doesn't, we don't.

## How has this change been tested?

Locally