### PR TITLE
use Fezziwig macros directly to explicitly build implicit decoder

### DIFF
--- a/app/util/AtomLogic.scala
+++ b/app/util/AtomLogic.scala
@@ -57,18 +57,17 @@ object AtomLogic extends Logging {
 object Parser extends Logging {
   import AtomLogic._
 
-  //These implicits speed up compilation
-  private implicit val atomDecoder = {
-    implicit val entityDecoder = Decoder[Entity]
-    implicit val imageAssetDecoder = Decoder[ImageAsset]
-    implicit val imageDecoder = Decoder[Image]
-    implicit val changeRecord = Decoder[ChangeRecord]
-    implicit val atomDataDecoder = Decoder[AtomData]
-    implicit val flagsDecoder = Decoder[Flags]
+  // These implicits speed up compilation (ie. are required to prevent massive memory usage at compilation)
+  private implicit val atomDecoder: Decoder[Atom] = {
+    implicit val entityDecoder: Decoder[Entity] = decodeThriftStruct[Entity]
+    implicit val imageAssetDecoder: Decoder[ImageAsset] = decodeThriftStruct[ImageAsset]
+    implicit val imageDecoder: Decoder[Image] = decodeThriftStruct[Image]
+    implicit val changeRecord: Decoder[ChangeRecord] = decodeThriftStruct[ChangeRecord]
+    implicit val atomDataDecoder: Decoder[AtomData] = decodeThriftUnion[AtomData]
+    implicit val flagsDecoder: Decoder[Flags] = decodeThriftStruct[Flags]
 
-    Decoder[Atom]
+    decodeThriftStruct[Atom]
   }
-
 
   def stringToAtom(atomString: String): Either[AtomAPIError, Atom] = {
     logger.info(s"Parsing atom json: $atomString")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Resolve the underlying problem which was indirectly fixed by #412 

Many many thanks to @emdash-ie who has seen and investigated a similar problem in the past - when the `atomDecoder` is being constructed, the final statement `Decoder[Atom]` is implicitly summoning an object of type `Decoder[Atom]`. At this point, the nearest object of type `Decocer[Atom]` is in fact the `atomDecoder` currently being constructed, so Scala attempts to provide the value of `atomDecoder` to the initializer of `atomDecoder`, which is an infinite loop which cannot work. As it happens, the actual value provided is `null` (as `atomDecoder` hasn't yet been initialised), so when the decoder is called implicitly in `jsonToAtom` a null pointer exception is thrown.

Instead of implicitly summoning any value of type `Decoder[Atom]`, we should explicitly call the Fezziwig macro which constructs a `Decoder`, so there is no confusion. We can then restore the type annotation and resolve the Scala compiler warning

## How has this change been tested?

Tested locally, creating and saving updates to a new atom.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
